### PR TITLE
Add ShowTicketService tests

### DIFF
--- a/backend/src/services/TicketServices/ShowTicketService.ts
+++ b/backend/src/services/TicketServices/ShowTicketService.ts
@@ -111,12 +111,12 @@ const ShowTicketService = async (
     ]
   });
 
-  if (ticket?.companyId !== companyId) {
-    throw new AppError("Não é possível consultar registros de outra empresa");
-  }
-
   if (!ticket) {
     throw new AppError("ERR_NO_TICKET_FOUND", 404);
+  }
+
+  if (ticket.companyId !== companyId) {
+    throw new AppError("Não é possível consultar registros de outra empresa");
   }
 
   return ticket;

--- a/backend/src/services/TicketServices/__tests__/ShowTicketService.spec.ts
+++ b/backend/src/services/TicketServices/__tests__/ShowTicketService.spec.ts
@@ -1,0 +1,23 @@
+import ShowTicketService from "../ShowTicketService";
+import Ticket from "../../../models/Ticket";
+import AppError from "../../../errors/AppError";
+
+describe("ShowTicketService", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws ERR_NO_TICKET_FOUND when ticket does not exist", async () => {
+    jest.spyOn(Ticket, "findOne").mockResolvedValue(null as any);
+
+    await expect(ShowTicketService(1, 1)).rejects.toThrow("ERR_NO_TICKET_FOUND");
+  });
+
+  it("throws when ticket belongs to another company", async () => {
+    jest.spyOn(Ticket, "findOne").mockResolvedValue({ companyId: 2 } as any);
+
+    await expect(ShowTicketService(1, 1)).rejects.toThrow(
+      "Não é possível consultar registros de outra empresa"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ShowTicketService error handling
- fix ShowTicketService to check for missing ticket before company validation

## Testing
- `npx jest --runInBand --no-cache` *(fails: Need to install jest)*


------
https://chatgpt.com/codex/tasks/task_e_683fc69d40108327a1581e043ddb8d52