### PR TITLE
Fix ticketTraking destroy call

### DIFF
--- a/backend/src/services/FacebookServices/facebookMessageListener.ts
+++ b/backend/src/services/FacebookServices/facebookMessageListener.ts
@@ -710,7 +710,7 @@ export const handleMessage = async (
                     amountUsedBotQueues: 0
                   })
 
-                  await ticketTraking.destroy;
+                  await ticketTraking.destroy();
 
                   return
                   //se digitou qualquer opção que não seja 1 ou 2 limpa o lgpdSendMessageAt para 


### PR DESCRIPTION
## Summary
- fix missing invocation of `destroy` in facebook message listener

## Testing
- `npm test` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc68e08088327bcb93a0eefc36db8