### PR TITLE
Fix comment language in CompaniesSettings

### DIFF
--- a/backend/src/models/CompaniesSettings.ts
+++ b/backend/src/models/CompaniesSettings.ts
@@ -41,7 +41,7 @@ import {
     @Column
     acceptCallWhatsapp: string;
 
-    //inicio de opções: enabled ou disabled
+    // Opções válidas: "enabled" ou "disabled"
     @Column
     userRandom: string; 
 
@@ -93,7 +93,7 @@ import {
     @Column
     lgpdLink: string
 
-    //fim de opções: enabled ou disabled 
+    // Opções válidas: "enabled" ou "disabled"
     @Column
     lgpdMessage: string
 


### PR DESCRIPTION
## Summary
- update comment about valid settings options to be more consistent

## Testing
- `npm test` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc69c7d9883279785ab1b6ee7f28b