### PR TITLE
Add placeholder pages for Leads and Chip Maturation

### DIFF
--- a/frontend/src/layout/MainListItems.js
+++ b/frontend/src/layout/MainListItems.js
@@ -840,6 +840,18 @@ const MainListItems = ({ collapsed, drawerClose }) => {
                 />
               )}
             />
+                <ListItemLink
+                  to="/leads"
+                  primary={i18n.t("mainDrawer.listItems.leads")}
+                  icon={<ListAlt />}
+                  tooltip={collapsed}
+                />
+                <ListItemLink
+                  to="/chip-maturation"
+                  primary={i18n.t("mainDrawer.listItems.chipMaturation")}
+                  icon={<GridOn />}
+                  tooltip={collapsed}
+                />
           )}
             {/* {user.super && (
               <ListSubheader inset>

--- a/frontend/src/pages/ChipMaturation/index.js
+++ b/frontend/src/pages/ChipMaturation/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+import MainContainer from "../../components/MainContainer";
+import MainHeader from "../../components/MainHeader";
+import Title from "../../components/Title";
+import { Typography } from "@material-ui/core";
+import { i18n } from "../../translate/i18n";
+
+const ChipMaturation = () => {
+  return (
+    <MainContainer>
+      <MainHeader>
+        <Title>{i18n.t("chipMaturation.title")}</Title>
+      </MainHeader>
+      <Typography>{i18n.t("chipMaturation.message")}</Typography>
+    </MainContainer>
+  );
+};
+
+export default ChipMaturation;

--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -1,0 +1,19 @@
+import React from "react";
+import MainContainer from "../../components/MainContainer";
+import MainHeader from "../../components/MainHeader";
+import Title from "../../components/Title";
+import { Typography } from "@material-ui/core";
+import { i18n } from "../../translate/i18n";
+
+const Leads = () => {
+  return (
+    <MainContainer>
+      <MainHeader>
+        <Title>{i18n.t("leads.title")}</Title>
+      </MainHeader>
+      <Typography>{i18n.t("leads.message")}</Typography>
+    </MainContainer>
+  );
+};
+
+export default Leads;

--- a/frontend/src/routes/index.js
+++ b/frontend/src/routes/index.js
@@ -48,6 +48,8 @@ import Files from "../pages/Files";
 import ToDoList from "../pages/ToDoList";
 import Kanban from "../pages/Kanban";
 import TagsKanban from "../pages/TagsKanban";
+import Leads from "../pages/Leads";
+import ChipMaturation from "../pages/ChipMaturation";
 const Routes = () => {
   const [showCampaigns, setShowCampaigns] = useState(false);
 
@@ -109,6 +111,8 @@ const Routes = () => {
                 <Route exact path="/chats/:id?" component={Chat} isPrivate />
                 <Route exact path="/files" component={Files} isPrivate />
                 <Route exact path="/moments" component={ChatMoments} isPrivate />
+                <Route exact path="/leads" component={Leads} isPrivate />
+                <Route exact path="/chip-maturation" component={ChipMaturation} isPrivate />
                 <Route exact path="/Kanban" component={Kanban} isPrivate />
                 <Route exact path="/TagsKanban" component={TagsKanban} isPrivate />
                 <Route exact path="/prompts" component={Prompts} isPrivate />

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -256,6 +256,8 @@ const messages = {
 					administration: "Administration",
 					users: "Users",
 					settings: "Settings",
+                                        leads: "Leads",
+                                        chipMaturation: "Chip Maturation"
 				},
 				appBar: {
 					user: {
@@ -320,6 +322,14 @@ const messages = {
 					},
 				},
 			},
+                        leads: {
+                                title: "Leads",
+                                message: "Page under development."
+                        },
+                        chipMaturation: {
+                                title: "Chip Maturation",
+                                message: "Page under development."
+                        },
 			messagesList: {
 				header: {
 					assignedTo: "Assigned to:",

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -868,6 +868,8 @@ const messages = {
           kanban: "Kanban",
           prompts: "Talk.Ai",
           allConnections: "Admin conexiones",
+          leads: "Leads",
+          chipMaturation: "Maduración de Chip"
         },
         appBar: {
           user: {
@@ -1456,6 +1458,14 @@ const messages = {
           deleteMessage: "Estás seguro de borrar este listado?",
           deleteAllMessage: "Estás seguro de borrar todos los listado?",
         },
+      },
+      leads: {
+        title: "Leads",
+        message: "Página en desarrollo."
+      },
+      chipMaturation: {
+        title: "Maduración de Chip",
+        message: "Página en desarrollo."
       },
       settings: {
         success: "Configuración guardada satisfactoriamente.",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -894,6 +894,8 @@ const messages = {
           allConnections: "Gerenciar conexões",
           reports: "Relatórios",
           management: "Gerência"
+          leads: "Leads",
+          chipMaturation: "Maturação de Chip"
         },
         appBar: {
           user: {
@@ -1514,6 +1516,14 @@ const messages = {
           deleteMessage: "Tem certeza que deseja deletar esta lista?",
           deleteAllMessage: "Tem certeza que deseja deletar todas as listas?",
         },
+      },
+      leads: {
+        title: "Leads",
+        message: "Página em desenvolvimento."
+      },
+      chipMaturation: {
+        title: "Maturação de Chip",
+        message: "Página em desenvolvimento."
       },
       settings: {
         success: "Configurações salvas com sucesso.",


### PR DESCRIPTION
## Summary
- add new pages `Leads` and `ChipMaturation`
- wire the new pages into the router
- add menu entries in the sidebar
- update i18n translation files

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_684453e085088327a97980075f84197b