### PR TITLE
Add tests for controllers and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: npm ci
+        working-directory: backend
+      - name: Run tests
+        run: npm test
+        working-directory: backend

--- a/backend/src/controllers/__tests__/ApiController.spec.ts
+++ b/backend/src/controllers/__tests__/ApiController.spec.ts
@@ -1,0 +1,64 @@
+import { checkNumber } from "../ApiController";
+import Whatsapp from "../../models/Whatsapp";
+import GetDefaultWhatsApp from "../../helpers/GetDefaultWhatsApp";
+import { getWbot } from "../../libs/wbot";
+
+jest.mock("../../models/Whatsapp");
+jest.mock("../../helpers/GetDefaultWhatsApp");
+jest.mock("../../libs/wbot", () => ({ getWbot: jest.fn() }));
+
+describe("ApiController checkNumber", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 when number exists", async () => {
+    const req: any = {
+      body: { number: "5511999999999" },
+      headers: { authorization: "Bearer token" }
+    };
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const res: any = { status };
+
+    (Whatsapp.findOne as jest.Mock).mockResolvedValue({ id: 1, companyId: 1 });
+    (GetDefaultWhatsApp as jest.Mock).mockResolvedValue({ id: 1 });
+    (getWbot as jest.Mock).mockReturnValue({
+      onWhatsApp: jest.fn().mockResolvedValue([{ exists: true, jid: "5511999999999@s.whatsapp.net" }])
+    });
+
+    await checkNumber(req, res);
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({
+      existsInWhatsapp: true,
+      number: "5511999999999",
+      numberFormatted: "5511999999999@s.whatsapp.net"
+    });
+  });
+
+  it("returns 400 when number is invalid", async () => {
+    const req: any = {
+      body: { number: "5511999999999" },
+      headers: { authorization: "Bearer token" }
+    };
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const res: any = { status };
+
+    (Whatsapp.findOne as jest.Mock).mockResolvedValue({ id: 1, companyId: 1 });
+    (GetDefaultWhatsApp as jest.Mock).mockResolvedValue({ id: 1 });
+    (getWbot as jest.Mock).mockReturnValue({
+      onWhatsApp: jest.fn().mockRejectedValue(new Error("fail"))
+    });
+
+    await checkNumber(req, res);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({
+      existsInWhatsapp: false,
+      number: "5511999999999@s.whatsapp.net",
+      error: "Not exists on Whatsapp"
+    });
+  });
+});

--- a/backend/src/services/UserServices/__tests__/ShowUserService.spec.ts
+++ b/backend/src/services/UserServices/__tests__/ShowUserService.spec.ts
@@ -1,0 +1,25 @@
+import ShowUserService from "../ShowUserService";
+import User from "../../../models/User";
+
+jest.mock("../../../models/User");
+
+describe("ShowUserService", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("throws ERR_NO_USER_FOUND when user does not exist", async () => {
+    (User.findOne as jest.Mock).mockResolvedValue(null);
+
+    await expect(ShowUserService(1, 1)).rejects.toThrow("ERR_NO_USER_FOUND");
+  });
+
+  it("returns user when found", async () => {
+    const userData = { id: 1, companyId: 1 } as any;
+    (User.findOne as jest.Mock).mockResolvedValue(userData);
+
+    const result = await ShowUserService(1, 1);
+
+    expect(result).toBe(userData);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for `ShowUserService`
- add Jest tests for `ApiController`
- configure GitHub Actions to run backend tests

## Testing
- `npm test --prefix backend` *(fails: `npm ERR! command git --no-replace-objects ls-remote ssh://git@github.com/digaovaa/Baileys.git`)*

------
https://chatgpt.com/codex/tasks/task_e_684495dadd0c832798ba06cc6359d5ab