### PR TITLE
Fix type mismatch in CreditController

### DIFF
--- a/backend/src/controllers/CreditController.ts
+++ b/backend/src/controllers/CreditController.ts
@@ -15,10 +15,12 @@ export const addCredits = async (req: Request, res: Response): Promise<Response>
   const parsedAmount = Number(amount);
   const parsedCompanyId = Number(companyId);
 
+  const userId = parseInt(id);
+
   if (isNaN(parsedAmount) || isNaN(parsedCompanyId)) {
     return res.status(400).json({ error: "Parâmetros inválidos" });
   }
 
-  const balance = await AddCreditsService(parsedCompanyId, parsedAmount, id);
+  const balance = await AddCreditsService(parsedCompanyId, parsedAmount, userId);
   return res.status(200).json({ balance });
 };


### PR DESCRIPTION
## Summary
- ensure the user id is parsed to a number before calling AddCreditsService

## Testing
- `npm run build` *(fails: Property 'update' does not exist on type 'Whatsapp' & other missing dependencies)*
- `npm test` *(fails: `sequelize` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455c1b62788327b563f2a0fe3fa353