### PR TITLE
Fix credits companies loading loop

### DIFF
--- a/frontend/src/components/CreditsManager/index.js
+++ b/frontend/src/components/CreditsManager/index.js
@@ -33,7 +33,8 @@ export default function CreditsManager() {
       setLoading(false);
     };
     fetchData();
-  }, [list]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleChangeAmount = (id, value) => {
     setAmounts((prev) => ({ ...prev, [id]: value }));


### PR DESCRIPTION
## Summary
- prevent unnecessary reruns of companies load effect

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_684570dcd7fc83278e78bcf584814c7f