### PR TITLE
Add CPF credit info and controls

### DIFF
--- a/frontend/src/components/LeadDetailModal/index.js
+++ b/frontend/src/components/LeadDetailModal/index.js
@@ -57,6 +57,8 @@ const useStyles = makeStyles((theme) => ({
   fieldRow: {
     display: 'flex',
     alignItems: 'center',
+    flexWrap: 'wrap',
+    wordBreak: 'break-word',
     marginBottom: theme.spacing(1),
     gap: theme.spacing(1),
   },

--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -46,6 +46,14 @@ const useStyles = makeStyles((theme) => ({
       marginRight: theme.spacing(1),
     },
   },
+  creditsRow: {
+    display: "flex",
+    alignItems: "center",
+    marginBottom: theme.spacing(1),
+    "& > *": {
+      marginRight: theme.spacing(1),
+    },
+  },
   tableWrapper: {
     overflowX: "auto",
   },
@@ -184,6 +192,11 @@ const Leads = () => {
     setHasMore(false);
   };
 
+  const handleClearCpf = () => {
+    setCpf("");
+    setDetailData(null);
+  };
+
   const handleClearHistory = () => {
     setHistory([]);
     localStorage.removeItem("leadsHistory");
@@ -248,11 +261,19 @@ const Leads = () => {
       <MainHeader>
         <Title>{i18n.t("leads.title")}</Title>
       </MainHeader>
-      <Typography variant="subtitle1" gutterBottom>
-        {i18n.t("leads.creditsAvailable")}: {credits}
-      </Typography>
+      <div className={classes.creditsRow}>
+        <Typography variant="subtitle1" gutterBottom>
+          {i18n.t("leads.creditsAvailable")}: {credits}
+        </Typography>
+        <Button variant="outlined" color="primary" size="small">
+          {i18n.t("leads.addCredits")}
+        </Button>
+      </div>
       <Typography variant="body2" color="textSecondary" gutterBottom>
         {i18n.t("leads.creditInfo")}
+      </Typography>
+      <Typography variant="body2" color="textSecondary" gutterBottom>
+        {i18n.t("leads.cpfCreditInfo")}
       </Typography>
 
       <div className={classes.form}>
@@ -317,6 +338,14 @@ const Leads = () => {
             disabled={loading}
           >
             Consultar CPF
+          </Button>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={handleClearCpf}
+            disabled={loading}
+          >
+            Limpar
           </Button>
         </div>
       )}

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -338,6 +338,8 @@ const messages = {
                                 },
                                 creditsAvailable: "Available credits",
                                 creditInfo: "Each batch of 15 leads costs 1 credit",
+                                cpfCreditInfo: "Each CPF lookup costs 3 credits",
+                                addCredits: "Add credits",
                                 historyCleared: "History cleared successfully",
                                 noCredits: "You do not have enough credits",
                                 message: "Page under development."

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -1463,6 +1463,8 @@ const messages = {
         title: "Leads",
         creditsAvailable: "Créditos disponibles",
         creditInfo: "Cada grupo de 15 leads consume 1 crédito",
+        cpfCreditInfo: "Cada consulta de CPF cuesta 3 créditos",
+        addCredits: "Acreditar créditos",
         noCredits: "No tienes créditos suficientes",
         historyCleared: "Historial borrado correctamente",
         message: "Página en desarrollo."

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -1534,6 +1534,8 @@ const messages = {
         },
         creditsAvailable: "Créditos disponíveis",
         creditInfo: "Cada consulta de 15 leads consome 1 crédito",
+        cpfCreditInfo: "Cada consulta de CPF custa 3 créditos",
+        addCredits: "Creditar créditos",
         historyCleared: "Histórico apagado com sucesso",
         noCredits: "Você não possui créditos suficientes",
         message: "Página em desenvolvimento."


### PR DESCRIPTION
## Summary
- show cost of CPF lookups
- add button to credit account
- allow clearing CPF field
- improve job detail wrapping
- update translations

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm test --silent` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f6f7c87483278f5dc7105b21d4dc