### PR TITLE
Fix company creation with credits

### DIFF
--- a/backend/src/controllers/CompanyController.ts
+++ b/backend/src/controllers/CompanyController.ts
@@ -44,6 +44,7 @@ type CompanyData = {
   recurrence?: string;
   document?: string;
   paymentMethod?: string;
+  credits?: number;
 };
 
 type SchedulesData = {
@@ -84,6 +85,7 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
 
   const schema = Yup.object().shape({
     name: Yup.string().required(),
+    credits: Yup.number(),
     password: Yup.string().required().min(5)
   });
 
@@ -153,7 +155,8 @@ export const update = async (
   const companyData: CompanyData = req.body;
 
   const schema = Yup.object().shape({
-    name: Yup.string()
+    name: Yup.string(),
+    credits: Yup.number()
   });
 
   try {

--- a/backend/src/controllers/api/CompanyController.ts
+++ b/backend/src/controllers/api/CompanyController.ts
@@ -41,6 +41,7 @@ type CompanyData = {
   recurrence?: string;
   document?: string;
   paymentMethod?: string;
+  credits?: number;
 };
 
 type SchedulesData = {
@@ -100,6 +101,7 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
       ),
     phone: Yup.string(),
     email: Yup.string(),
+    credits: Yup.number(),
     planId: Yup.number().required(),
     password: Yup.string().required().min(5)
   });
@@ -165,6 +167,7 @@ export const update = async (
       ),
     phone: Yup.string(),
     email: Yup.string(),
+    credits: Yup.number(),
     document: Yup.string()
       .min(11, "ERR_COMPANY_INVALID_DOCUMENT")
       .max(14, "ERR_COMPANY_INVALID_DOCUMENT")

--- a/backend/src/services/CompanyService/CreateCompanyService.ts
+++ b/backend/src/services/CompanyService/CreateCompanyService.ts
@@ -17,6 +17,7 @@ interface CompanyData {
   paymentMethod?: string;
   password?: string;
   companyUserName?: string;
+  credits?: number;
 }
 
 const CreateCompanyService = async (
@@ -33,7 +34,8 @@ const CreateCompanyService = async (
     recurrence,
     document,
     paymentMethod,
-    companyUserName
+    companyUserName,
+    credits = 0
   } = companyData;
 
   const companySchema = Yup.object().shape({
@@ -51,17 +53,19 @@ const CreateCompanyService = async (
   const t = await sequelize.transaction();
 
   try {
-    const company = await Company.create({
-      name,
-      phone,
-      email,
-      status,
-      planId,
-      dueDate,
-      recurrence,
-      document,
-      paymentMethod
-    },
+    const company = await Company.create(
+      {
+        name,
+        phone,
+        email,
+        status,
+        planId,
+        dueDate,
+        recurrence,
+        document,
+        paymentMethod,
+        credits
+      },
       { transaction: t }
     );
 

--- a/backend/src/services/CompanyService/UpdateCompanyService.ts
+++ b/backend/src/services/CompanyService/UpdateCompanyService.ts
@@ -18,6 +18,7 @@ interface CompanyData {
   document?: string;
   paymentMethod?: string;
   password?: string;
+  credits?: number;
 }
 
 const UpdateCompanyService = async (
@@ -36,7 +37,8 @@ const UpdateCompanyService = async (
     recurrence,
     document,
     paymentMethod,
-    password
+    password,
+    credits = company.credits
   } = companyData;
 
   if (!company) {
@@ -110,7 +112,8 @@ const UpdateCompanyService = async (
     dueDate,
     recurrence,
     document,
-    paymentMethod
+    paymentMethod,
+    credits
   });
 
   if (companyData.campaignsEnabled !== undefined) {


### PR DESCRIPTION
## Summary
- accept `credits` field when creating or updating a company
- persist credits in company creation and update services

## Testing
- `npm run lint` *(fails: ESLint configuration missing)*
- `npm test` *(fails: sequelize not found)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68472e1ccd3c8327889c8f0c82f82dfe