### PR TITLE
Fix dark mode toggle behavior

### DIFF
--- a/frontend/src/layout/index.js
+++ b/frontend/src/layout/index.js
@@ -324,10 +324,15 @@ const LoggedInLayout = ({ children, themeToggle }) => {
         setDrawerOpen(true);
       }
     }
+  }, [user.defaultMenu]);
+
+  useEffect(() => {
     if (user.defaultTheme === "dark" && theme.mode === "light") {
       colorMode.toggleColorMode();
+    } else if (user.defaultTheme === "light" && theme.mode === "dark") {
+      colorMode.toggleColorMode();
     }
-  }, [user.defaultMenu, document.body.offsetWidth]);
+  }, [user.defaultTheme]);
 
   useEffect(() => {
     if (document.body.offsetWidth < 600) {


### PR DESCRIPTION
## Summary
- ensure layout only toggles theme when `user.defaultTheme` changes
- respect manual light/dark setting

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475f139ba483279fa115c2f130eb6c