### PR TITLE
Improve chip maturation workflow

### DIFF
--- a/frontend/src/pages/ChipMaturation/index.js
+++ b/frontend/src/pages/ChipMaturation/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import MainContainer from "../../components/MainContainer";
 import MainHeader from "../../components/MainHeader";
 import Title from "../../components/Title";
@@ -6,6 +6,8 @@ import {
   Typography,
   Paper,
   TextField,
+  Select,
+  MenuItem,
   Button,
   Grid,
   LinearProgress,
@@ -17,12 +19,16 @@ import {
   listMaturations,
   cancelMaturation,
 } from "../../services/maturacaoApi";
+import { WhatsAppsContext } from "../../context/WhatsApp/WhatsAppsContext";
 
 const ChipMaturation = () => {
+  const { whatsApps } = useContext(WhatsAppsContext);
   const [chip, setChip] = useState("");
   const [days, setDays] = useState(1);
   const [conversations, setConversations] = useState("");
   const [jobs, setJobs] = useState([]);
+
+  const activeConnections = whatsApps?.filter(w => w.status === "CONNECTED") || [];
 
   const fetchJobs = async () => {
     try {
@@ -66,12 +72,25 @@ const ChipMaturation = () => {
       <Grid container spacing={2}>
         <Grid item xs={12} md={4}>
           <Paper style={{ padding: 16 }}>
-            <TextField
-              label={i18n.t("chipMaturation.chipLabel")}
+            <Select
               fullWidth
+              displayEmpty
               value={chip}
               onChange={(e) => setChip(e.target.value)}
-            />
+              renderValue={() => {
+                if (!chip) {
+                  return i18n.t("chipMaturation.chipLabel");
+                }
+                const conn = activeConnections.find(c => String(c.number) === chip);
+                return conn ? `${conn.name} (${conn.number})` : chip;
+              }}
+            >
+              {activeConnections.map((conn) => (
+                <MenuItem key={conn.id} value={String(conn.number)}>
+                  {conn.name} ({conn.number})
+                </MenuItem>
+              ))}
+            </Select>
             <TextField
               type="number"
               label={i18n.t("chipMaturation.daysLabel")}

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -347,7 +347,7 @@ const messages = {
                         },
                         chipMaturation: {
                                 title: "Chip Maturation",
-                                chipLabel: "Chip Number",
+                                chipLabel: "Select Connection",
                                 daysLabel: "Days",
                                 conversationLabel: "Conversations (one per line)",
                                 startButton: "Start Maturation",

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -1472,7 +1472,7 @@ const messages = {
       },
       chipMaturation: {
         title: "Maduración de Chip",
-        chipLabel: "Número del Chip",
+        chipLabel: "Seleccione la Conexión",
         daysLabel: "Días",
         conversationLabel: "Conversaciones (una por línea)",
         startButton: "Iniciar Maduración",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -1543,7 +1543,7 @@ const messages = {
       },
       chipMaturation: {
         title: "Maturação de Chip",
-        chipLabel: "Número do Chip",
+        chipLabel: "Selecione a Conexão",
         daysLabel: "Dias",
         conversationLabel: "Conversas (uma por linha)",
         startButton: "Iniciar Maturação",


### PR DESCRIPTION
## Summary
- show active connections to select in chip maturation page
- update translations for new connection dropdown label

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496233bbc88327aed529cd2b9cf20d