### PR TITLE
Remove undefined argument from ws.close

### DIFF
--- a/backend/src/libs/wbot.ts
+++ b/backend/src/libs/wbot.ts
@@ -112,7 +112,7 @@ export const restartWbot = async (
     whatsapp.map(async c => {
       const sessionIndex = sessions.findIndex(s => s.id === c.id);
       if (sessionIndex !== -1) {
-        sessions[sessionIndex].ws.close(undefined);
+        sessions[sessionIndex].ws.close();
       }
 
     });


### PR DESCRIPTION
## Summary
- fix ws.close call when restarting Wbot session

## Testing
- `npm install`
- `npm run build` *(fails: Module '@whiskeysockets/baileys' has no exported member 'makeInMemoryStore')*

------
https://chatgpt.com/codex/tasks/task_e_6849a678d77083278e661c41493ae155