### PR TITLE
Fix includes cast

### DIFF
--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -5118,7 +5118,7 @@ const filterMessages = (msg: WAMessage): boolean => {
       WAMessageStubType.E2E_DEVICE_CHANGED,
       WAMessageStubType.E2E_IDENTITY_CHANGED,
       WAMessageStubType.CIPHERTEXT
-    ].includes(msg.messageStubType as WAMessageStubType)
+    ].includes(msg.messageStubType as any)
   )
     return false;
 


### PR DESCRIPTION
## Summary
- replace WAMessageStubType cast when filtering messages

## Testing
- `npm run build` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6849a8ab12308327bc153420871a6fb3