### PR TITLE
Fix stack overflow on socket emission

### DIFF
--- a/backend/src/services/MaturationService/MaturationManager.ts
+++ b/backend/src/services/MaturationService/MaturationManager.ts
@@ -94,9 +94,12 @@ class MaturationManager {
   }
 
   private serializeJob(job: MaturationJob) {
+    const { timeout, ...rest } = job;
     return {
-      ...job,
-      progress: (Date.now() - job.startAt.getTime()) / (job.endAt.getTime() - job.startAt.getTime())
+      ...rest,
+      progress:
+        (Date.now() - job.startAt.getTime()) /
+        (job.endAt.getTime() - job.startAt.getTime())
     };
   }
 


### PR DESCRIPTION
## Summary
- avoid serializing NodeJS timeout when emitting maturation job updates

## Testing
- `npm test` (fails: sequelize and react-scripts not found)
- `npm run lint` in backend (fails: ESLint config missing)


------
https://chatgpt.com/codex/tasks/task_e_6849df67aa448327a43e04cddce859f2