### PR TITLE
Fix maturation job init on startup

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -30,16 +30,10 @@ if (process.env.CERTIFICADOS == "true") {
       attributes: ["id"]
     });
 
-    const allPromises: any[] = [];
-    companies.map(async c => {
-      const promise = StartAllWhatsAppsSessions(c.id);
-      allPromises.push(promise);
-    });
-
-    Promise.all(allPromises).then(async () => {
+      const sessionPromises = companies.map(c => StartAllWhatsAppsSessions(c.id));
+      await Promise.allSettled(sessionPromises);
       await startQueueProcess();
       await initMaturations();
-    });
 
     if (process.env.REDIS_URI_ACK && process.env.REDIS_URI_ACK !== '') {
       BullQueue.process();
@@ -73,16 +67,10 @@ if (process.env.CERTIFICADOS == "true") {
       attributes: ["id"]
     });
   
-    const allPromises: any[] = [];
-    companies.map(async c => {
-      const promise = StartAllWhatsAppsSessions(c.id);
-      allPromises.push(promise);
-    });
-  
-    Promise.all(allPromises).then(async () => {
+      const sessionPromises = companies.map(c => StartAllWhatsAppsSessions(c.id));
+      await Promise.allSettled(sessionPromises);
       await startQueueProcess();
       await initMaturations();
-    });
   
     if (process.env.REDIS_URI_ACK && process.env.REDIS_URI_ACK !== '') {
       BullQueue.process();


### PR DESCRIPTION
## Summary
- ensure chip maturation jobs resume after server restart

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6849e1591f0083279c4bb979705502eb