### PR TITLE
Add minute interval for chip maturation

### DIFF
--- a/backend/src/controllers/MaturationController.ts
+++ b/backend/src/controllers/MaturationController.ts
@@ -18,7 +18,7 @@ export const index = (req: Request, res: Response): Response => {
 };
 
 export const store = async (req: Request, res: Response): Promise<Response> => {
-  const { originChipId, targetChipIds, days, intervalHours, conversations, companyId } = req.body;
+  const { originChipId, targetChipIds, days, intervalHours, intervalMinutes, conversations, companyId } = req.body;
   if (!originChipId || !targetChipIds?.length || !conversations || !Array.isArray(conversations) || !days) {
     return res.status(400).json({ error: "Invalid data" });
   }
@@ -26,7 +26,8 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
     originChipId,
     targetChipIds,
     days: Number(days),
-    intervalHours: Number(intervalHours) || 1,
+    intervalHours: Number(intervalHours) || 0,
+    intervalMinutes: Number(intervalMinutes) || ((Number(intervalHours) || 1) * 60),
     conversations,
     companyId
   });

--- a/backend/src/database/migrations/20250625010105-add-intervalMinutes-to-chip-maturations.ts
+++ b/backend/src/database/migrations/20250625010105-add-intervalMinutes-to-chip-maturations.ts
@@ -1,0 +1,14 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.addColumn("ChipMaturations", "intervalMinutes", {
+      type: DataTypes.INTEGER,
+      defaultValue: 60
+    });
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.removeColumn("ChipMaturations", "intervalMinutes");
+  }
+};

--- a/backend/src/models/ChipMaturation.ts
+++ b/backend/src/models/ChipMaturation.ts
@@ -28,6 +28,9 @@ class ChipMaturation extends Model<ChipMaturation> {
   @Column
   intervalHours: number;
 
+  @Column
+  intervalMinutes: number;
+
   @Column({ type: DataType.JSONB })
   conversations: string[];
 

--- a/backend/src/services/MaturationService/MaturationManager.ts
+++ b/backend/src/services/MaturationService/MaturationManager.ts
@@ -13,6 +13,7 @@ export interface MaturationJob {
   targetChipIds: string[];
   days: number;
   intervalHours: number;
+  intervalMinutes: number;
   conversations: string[];
   startAt: Date;
   endAt: Date;
@@ -32,7 +33,8 @@ class MaturationManager {
   }
 
   private scheduleNext(job: MaturationJob) {
-    const delay = job.intervalHours * 60 * 60 * 1000;
+    const interval = job.intervalMinutes || job.intervalHours * 60;
+    const delay = interval * 60 * 1000;
     job.timeout = setTimeout(() => this.executeJob(job.id), delay);
   }
 
@@ -111,7 +113,8 @@ class MaturationManager {
         originChipId: record.originChipId,
         targetChipIds: record.targetChipIds || [],
         days: record.days,
-        intervalHours: (record as any).intervalHours || 1,
+        intervalHours: (record as any).intervalHours || 0,
+        intervalMinutes: (record as any).intervalMinutes || ((record as any).intervalHours || 1) * 60,
         conversations: record.conversations || [],
         startAt: record.startAt,
         endAt: record.endAt,
@@ -131,6 +134,7 @@ class MaturationManager {
     targetChipIds: string[];
     days: number;
     intervalHours: number;
+    intervalMinutes: number;
     conversations: string[];
     companyId: number;
   }): Promise<MaturationJob> {
@@ -144,6 +148,7 @@ class MaturationManager {
       targetChipIds: data.targetChipIds,
       days: data.days,
       intervalHours: data.intervalHours,
+      intervalMinutes: data.intervalMinutes,
       conversations: data.conversations,
       startAt,
       endAt,
@@ -157,6 +162,7 @@ class MaturationManager {
       targetChipIds: data.targetChipIds,
       days: data.days,
       intervalHours: data.intervalHours,
+      intervalMinutes: data.intervalMinutes,
       conversations: data.conversations,
       startAt,
       endAt,

--- a/backend/src/services/MaturationService/index.ts
+++ b/backend/src/services/MaturationService/index.ts
@@ -5,6 +5,7 @@ interface CreateMaturationData {
   targetChipIds: string[];
   days: number;
   intervalHours: number;
+  intervalMinutes: number;
   conversations: string[];
   companyId: number;
 }

--- a/frontend/src/pages/ChipMaturation/index.js
+++ b/frontend/src/pages/ChipMaturation/index.js
@@ -36,7 +36,7 @@ const ChipMaturation = () => {
   const [origin, setOrigin] = useState("");
   const [targets, setTargets] = useState([]);
   const [days, setDays] = useState(1);
-  const [intervalHours, setIntervalHours] = useState(1);
+  const [intervalMinutes, setIntervalMinutes] = useState(60);
   const [conversations, setConversations] = useState("");
   const [jobs, setJobs] = useState([]);
   const [activeStep, setActiveStep] = useState(0);
@@ -67,10 +67,10 @@ const ChipMaturation = () => {
   }, [targets]);
 
   useEffect(() => {
-    if (activeStep === 2 && days && intervalHours) {
+    if (activeStep === 2 && days && intervalMinutes) {
       setActiveStep(3);
     }
-  }, [days, intervalHours]);
+  }, [days, intervalMinutes]);
 
   useEffect(() => {
     fetchJobs();
@@ -99,7 +99,7 @@ const ChipMaturation = () => {
         originChipId: origin,
         targetChipIds: targets,
         days: Number(days),
-        intervalHours: Number(intervalHours),
+        intervalMinutes: Number(intervalMinutes),
         conversations: conversations
           .split(/\r?\n/)
           .map((l) => l.trim())
@@ -203,8 +203,8 @@ const ChipMaturation = () => {
                     style={{ marginTop: 8 }}
                     label={i18n.t("chipMaturation.intervalLabel")}
                     fullWidth
-                    value={intervalHours}
-                    onChange={(e) => setIntervalHours(e.target.value)}
+                    value={intervalMinutes}
+                    onChange={(e) => setIntervalMinutes(e.target.value)}
                   />
                 </StepContent>
               </Step>

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -356,7 +356,7 @@ const messages = {
                                 step_messages: "Messages",
                                daysLabel: "Days",
                                conversationLabel: "Conversations (one per line)",
-                               intervalLabel: "Interval (hours)",
+                               intervalLabel: "Interval (minutes)",
                                startButton: "Start Maturation",
                                 historyButton: "View history",
                                cancelButton: "Stop",

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -1478,7 +1478,7 @@ const messages = {
         step_schedule: "Defina Días e Intervalo",
         daysLabel: "Días",
         conversationLabel: "Conversaciones (una por línea)",
-        intervalLabel: "Intervalo (horas)",
+        intervalLabel: "Intervalo (minutos)",
         startButton: "Iniciar Maduración",
         cancelButton: "Interrumpir",
         started: "Maduración iniciada",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -1552,7 +1552,7 @@ const messages = {
         step_messages: "Mensagens",
         daysLabel: "Dias",
         conversationLabel: "Conversas (uma por linha)",
-        intervalLabel: "Intervalo (horas)",
+        intervalLabel: "Intervalo (minutos)",
         startButton: "Iniciar Maturação",
         historyButton: "Ver histórico",
         cancelButton: "Interromper",


### PR DESCRIPTION
## Summary
- add database migration for interval minutes
- track interval minutes on ChipMaturation model and services
- allow setting minutes in maturation controller
- update React page and translations for minute interval

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm test -- -w 4` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e08077c688327814f23f867e8c244