### PR TITLE
Add management for conversation lists

### DIFF
--- a/backend/src/controllers/ChipConversationController.ts
+++ b/backend/src/controllers/ChipConversationController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from "express";
 import * as ChipConversationService from "../services/ChipConversationService";
+import { getIO } from "../libs/socket";
 
 export const index = async (req: Request, res: Response): Promise<Response> => {
   const { companyId } = req.user;
@@ -21,4 +22,16 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
     .filter(Boolean);
   const list = await ChipConversationService.createList({ name, messages, companyId });
   return res.status(201).json(list);
+};
+
+export const remove = async (req: Request, res: Response): Promise<Response> => {
+  const { id } = req.params;
+  const { companyId } = req.user;
+  await ChipConversationService.deleteList(id);
+  const io = getIO();
+  io.of(String(companyId)).emit(`company-${companyId}-conversationList`, {
+    action: "delete",
+    id
+  });
+  return res.status(200).json({});
 };

--- a/backend/src/routes/chipConversationRoutes.ts
+++ b/backend/src/routes/chipConversationRoutes.ts
@@ -9,5 +9,6 @@ const upload = multer();
 
 routes.get("/conversation-lists", isAuth, ChipConversationController.index);
 routes.post("/conversation-lists", isAuth, isSuper, upload.single("file"), ChipConversationController.store);
+routes.delete("/conversation-lists/:id", isAuth, isSuper, ChipConversationController.remove);
 
 export default routes;

--- a/backend/src/services/ChipConversationService.ts
+++ b/backend/src/services/ChipConversationService.ts
@@ -1,5 +1,6 @@
 import ChipConversationList from "../models/ChipConversationList";
 import { v4 as uuid } from "uuid";
+import AppError from "../errors/AppError";
 
 interface CreateData {
   name: string;
@@ -15,4 +16,12 @@ export const createList = async ({ name, messages, companyId }: CreateData) => {
 
 export const listLists = async (companyId: number) => {
   return ChipConversationList.findAll({ where: { companyId } });
+};
+
+export const deleteList = async (id: string): Promise<void> => {
+  const list = await ChipConversationList.findOne({ where: { id } });
+  if (!list) {
+    throw new AppError("ERR_NO_CONVERSATION_LIST_FOUND", 404);
+  }
+  await list.destroy();
 };

--- a/frontend/src/components/Settings/ChipConversationUpload.js
+++ b/frontend/src/components/Settings/ChipConversationUpload.js
@@ -1,8 +1,20 @@
-import React, { useState } from "react";
-import { TextField, Button } from "@material-ui/core";
+import React, { useState, useEffect } from "react";
+import {
+  TextField,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+} from "@material-ui/core";
+import DeleteOutlineIcon from "@material-ui/icons/DeleteOutline";
 import { makeStyles } from "@material-ui/core/styles";
 import { toast } from "react-toastify";
-import { uploadConversationList } from "../../services/conversationListApi";
+import {
+  uploadConversationList,
+  listConversationLists,
+  deleteConversationList,
+} from "../../services/conversationListApi";
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -17,6 +29,20 @@ const ChipConversationUpload = () => {
   const classes = useStyles();
   const [file, setFile] = useState(null);
   const [name, setName] = useState("");
+  const [lists, setLists] = useState([]);
+
+  const fetchLists = async () => {
+    try {
+      const { data } = await listConversationLists();
+      setLists(data);
+    } catch (err) {
+      // ignore
+    }
+  };
+
+  useEffect(() => {
+    fetchLists();
+  }, []);
 
   const handleSubmit = async e => {
     e.preventDefault();
@@ -32,28 +58,53 @@ const ChipConversationUpload = () => {
       toast.success("Lista enviada");
       setFile(null);
       setName("");
+      fetchLists();
     } catch (err) {
       toast.error("Erro ao enviar");
     }
   };
 
+  const handleDelete = async id => {
+    try {
+      await deleteConversationList(id);
+      fetchLists();
+    } catch (err) {
+      toast.error("Erro ao excluir");
+    }
+  };
+
   return (
-    <form onSubmit={handleSubmit} className={classes.container}>
-      <TextField
-        label="Nome"
-        value={name}
-        onChange={e => setName(e.target.value)}
-        variant="outlined"
-      />
-      <input
-        type="file"
-        accept="text/plain"
-        onChange={e => setFile(e.target.files[0])}
-      />
-      <Button type="submit" variant="contained" color="primary">
-        Enviar
-      </Button>
-    </form>
+    <div className={classes.container}>
+      <form onSubmit={handleSubmit} className={classes.container}>
+        <TextField
+          label="Nome"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          variant="outlined"
+        />
+        <input
+          type="file"
+          accept="text/plain"
+          onChange={e => setFile(e.target.files[0])}
+        />
+        <Button type="submit" variant="contained" color="primary">
+          Enviar
+        </Button>
+      </form>
+      <List>
+        {lists.map(list => (
+          <ListItem key={list.id} dense>
+            <ListItemText
+              primary={list.name}
+              secondary={`${list.messages.length} mensagens`}
+            />
+            <IconButton edge="end" onClick={() => handleDelete(list.id)}>
+              <DeleteOutlineIcon />
+            </IconButton>
+          </ListItem>
+        ))}
+      </List>
+    </div>
   );
 };
 

--- a/frontend/src/services/conversationListApi.js
+++ b/frontend/src/services/conversationListApi.js
@@ -3,3 +3,5 @@ import api from "./api";
 export const listConversationLists = () => api.get("/conversation-lists");
 export const uploadConversationList = formData =>
   api.post("/conversation-lists", formData);
+export const deleteConversationList = id =>
+  api.delete(`/conversation-lists/${id}`);


### PR DESCRIPTION
## Summary
- allow super users to delete conversation lists
- list conversation lists in the settings upload component

## Testing
- `npm test` *(fails: sequelize/react-scripts not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ed4104ae48327bce503242fe98d68