### PR TITLE
Allow all companies to view conversation lists

### DIFF
--- a/backend/src/controllers/ChipConversationController.ts
+++ b/backend/src/controllers/ChipConversationController.ts
@@ -3,8 +3,7 @@ import * as ChipConversationService from "../services/ChipConversationService";
 import { getIO } from "../libs/socket";
 
 export const index = async (req: Request, res: Response): Promise<Response> => {
-  const { companyId } = req.user;
-  const data = await ChipConversationService.listLists(companyId);
+  const data = await ChipConversationService.listLists();
   return res.json(data);
 };
 

--- a/backend/src/services/ChipConversationService.ts
+++ b/backend/src/services/ChipConversationService.ts
@@ -14,8 +14,8 @@ export const createList = async ({ name, messages, companyId }: CreateData) => {
   return list;
 };
 
-export const listLists = async (companyId: number) => {
-  return ChipConversationList.findAll({ where: { companyId } });
+export const listLists = async () => {
+  return ChipConversationList.findAll();
 };
 
 export const deleteList = async (id: string): Promise<void> => {


### PR DESCRIPTION
## Summary
- remove company filter when fetching chip conversation lists
- update controller accordingly

## Testing
- `npm test` (backend) *(fails: `sequelize` not found)*
- `npm test -- -w=1` (frontend) *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef0180af48327a68a16557d225016