### PR TITLE
Fix ESLint prettier config

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -7,7 +7,7 @@
   "extends": [
     "airbnb-base",
     "plugin:@typescript-eslint/recommended",
-    "prettier/@typescript-eslint",
+    "prettier",
     "plugin:prettier/recommended"
   ],
   "parser": "@typescript-eslint/parser",


### PR DESCRIPTION
## Summary
- fix deprecated prettier/@typescript-eslint config in `backend/.eslintrc.json`

## Testing
- `npm install --omit=optional`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850b5b9833c83279977551052d0b9c3