### PR TITLE
Clean server cluster

### DIFF
--- a/backend/src/server-cluster.ts
+++ b/backend/src/server-cluster.ts
@@ -14,7 +14,7 @@ const PORT = process.env.PORT || 4000
 
 const clusterWorkerSize = os.cpus().length
 
-console.log('clusterWorkerSize', clusterWorkerSize)
+logger.info(`Cluster size: ${clusterWorkerSize}`)
 
 if (clusterWorkerSize > 1) {
   if (cluster.isMaster) {
@@ -23,7 +23,7 @@ if (clusterWorkerSize > 1) {
     }
 
     cluster.on("exit", function (worker) {
-      console.log("Worker", worker.id, " has exitted.")
+      logger.warn(`Worker ${worker.id} has exited.`)
     })
   } else {
     const app = express()
@@ -65,40 +65,6 @@ if (clusterWorkerSize > 1) {
   const app = express()
 
   app.listen(PORT, function () {
-    console.log(`Express server listening on port ${PORT} with the single worker ${process.pid}`)
+    logger.info(`Express server listening on port ${PORT} with the single worker ${process.pid}`)
   })
 }
-
-
-// const server = app.listen(process.env.PORT, async () => {
-//   const companies = await Company.findAll();
-//   const allPromises: any[] = [];
-//   companies.map(async c => {
-//     const promise = StartAllWhatsAppsSessions(c.id);
-//     allPromises.push(promise);
-//   });
-
-//   Promise.all(allPromises).then(async () => {
-//     await startQueueProcess();
-//   });
-//   logger.info(`Server started on port: ${process.env.PORT}`);
-// });
-
-// process.on("uncaughtException", err => {
-//   console.error(`${new Date().toUTCString()} uncaughtException:`, err.message);
-//   console.error(err.stack);
-//   process.exit(1);
-// });
-
-// process.on("unhandledRejection", (reason, p) => {
-//   console.error(
-//     `${new Date().toUTCString()} unhandledRejection:`,
-//     reason,
-//     p
-//   );
-//   process.exit(1);
-// });
-
-
-// initIO(server);
-// gracefulShutdown(server);


### PR DESCRIPTION
## Summary
- remove obsolete commented block in server-cluster
- replace console.log usage with logger

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6850b5c500348327aecffa0f97f21605