### PR TITLE
Fix Next.js build by declaring page as client component

### DIFF
--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { motion } from 'framer-motion'
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- mark landing page component with `"use client"` directive so Framer Motion can be imported

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850e90ebda4832794f914320485d9a0