### PR TITLE
Enhance landing page visuals

### DIFF
--- a/landing/app/components/CTA.tsx
+++ b/landing/app/components/CTA.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export default function CTA() {
+  return (
+    <section className="relative py-20 text-center text-white bg-gradient-to-br from-blue-700 via-blue-500 to-blue-400 font-[family-name:var(--font-geist-sans)]">
+      <h2 className="text-3xl sm:text-4xl font-bold mb-4">Pronto para transformar seu atendimento?</h2>
+      <p className="max-w-xl mx-auto text-lg mb-8">Crie sua conta e comece a automatizar agora mesmo.</p>
+      <a href="https://app.atendesolucao.com/signup" className="inline-block px-8 py-4 bg-white text-blue-700 rounded-md hover:bg-gray-100">Começar grátis</a>
+    </section>
+  )
+}
+

--- a/landing/app/components/Features.tsx
+++ b/landing/app/components/Features.tsx
@@ -1,22 +1,36 @@
 'use client'
+import Image from 'next/image'
 
 export default function Features() {
+  const features = [
+    {
+      icon: '/globe.svg',
+      title: 'Integração',
+      description: 'Conecte seus canais em um único lugar.'
+    },
+    {
+      icon: '/window.svg',
+      title: 'Automação',
+      description: 'Crie fluxos inteligentes e aumente a produtividade.'
+    },
+    {
+      icon: '/file.svg',
+      title: 'Relatórios',
+      description: 'Analise métricas e tome decisões embasadas.'
+    }
+  ]
+
   return (
-    <section className="bg-white text-gray-800 py-16">
+    <section className="bg-white text-gray-800 py-16 font-[family-name:var(--font-geist-sans)]">
       <div className="max-w-6xl mx-auto px-4 grid md:grid-cols-3 gap-8 text-center">
-        <div>
-          <h3 className="text-2xl font-semibold mb-2">Integração</h3>
-          <p>Conecte seus canais em um único lugar.</p>
-        </div>
-        <div>
-          <h3 className="text-2xl font-semibold mb-2">Automção</h3>
-          <p>Crie fluxos inteligentes e aumente a produtividade.</p>
-        </div>
-        <div>
-          <h3 className="text-2xl font-semibold mb-2">Relatórios</h3>
-          <p>Analise métricas e tome decisões embasadas.</p>
-        </div>
+        {features.map((f) => (
+          <div key={f.title} className="flex flex-col items-center">
+            <Image src={f.icon} alt="" width={48} height={48} className="mb-4" />
+            <h3 className="text-2xl font-semibold mb-2">{f.title}</h3>
+            <p>{f.description}</p>
+          </div>
+        ))}
       </div>
     </section>
-  );
+  )
 }

--- a/landing/app/components/Footer.tsx
+++ b/landing/app/components/Footer.tsx
@@ -2,7 +2,7 @@
 
 export default function Footer() {
   return (
-    <footer className="bg-gray-100 text-gray-600 text-center py-6 text-sm">
+    <footer className="bg-gray-100 text-gray-600 text-center py-6 text-sm font-[family-name:var(--font-geist-sans)]">
       <p>&copy; {new Date().getFullYear()} Atende Solução. Todos os direitos reservados.</p>
     </footer>
   );

--- a/landing/app/components/Hero.tsx
+++ b/landing/app/components/Hero.tsx
@@ -7,6 +7,16 @@ export default function Hero() {
     <section className="relative min-h-screen flex flex-col justify-center items-center text-center text-white font-[family-name:var(--font-geist-sans)] overflow-hidden">
       <div className="absolute inset-0 bg-gradient-to-br from-blue-700 via-blue-500 to-blue-400" />
       <div className="absolute inset-0 bg-[url('https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1950&q=80')] bg-cover bg-center opacity-30" />
+      <motion.div
+        className="absolute -left-20 -top-20 w-[30rem] h-[30rem] bg-blue-300 rounded-full blur-3xl opacity-40"
+        animate={{ rotate: 360 }}
+        transition={{ repeat: Infinity, duration: 30, ease: 'linear' }}
+      />
+      <motion.div
+        className="absolute right-0 -bottom-20 w-[40rem] h-[40rem] bg-blue-800 rounded-full blur-3xl opacity-30"
+        animate={{ rotate: -360 }}
+        transition={{ repeat: Infinity, duration: 40, ease: 'linear' }}
+      />
       <motion.h1
         initial={{ opacity: 0, y: 40 }}
         animate={{ opacity: 1, y: 0 }}
@@ -39,3 +49,4 @@ export default function Hero() {
     </section>
   )
 }
+

--- a/landing/app/components/Navbar.tsx
+++ b/landing/app/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 export default function Navbar() {
   return (
-    <nav className="absolute top-4 left-0 right-0 flex justify-between items-center px-6 z-20 text-white font-[family-name:var(--font-geist-sans)]">
+    <nav className="absolute top-4 left-0 right-0 flex justify-between items-center px-6 z-20 text-white font-[family-name:var(--font-geist-sans)] backdrop-blur-md bg-white/10 rounded-xl mx-4 py-2">
       <span className="text-xl font-semibold">Atende Solução</span>
       <div className="space-x-4">
         <a

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -1,6 +1,7 @@
 import Hero from './components/Hero'
 import Navbar from './components/Navbar'
 import Features from './components/Features'
+import CTA from './components/CTA'
 import Footer from './components/Footer'
 
 export const dynamic = 'force-dynamic'
@@ -11,6 +12,7 @@ export default function Home() {
       <Navbar />
       <Hero />
       <Features />
+      <CTA />
       <Footer />
     </div>
   )


### PR DESCRIPTION
## Summary
- add animated background elements in Hero
- display feature icons using next/image
- add CTA section encouraging signup
- polish navbar and fonts

## Testing
- `npm run lint`
- `npm run build`
- `npm run build` in landing succeeded
- backend and frontend tests couldn't run due to missing dependencies and setup

------
https://chatgpt.com/codex/tasks/task_e_68524925de0483278f82298eea32be54