### PR TITLE
Fix Tailwind CSS integration

### DIFF
--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -1,4 +1,6 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;

--- a/landing/tailwind.config.js
+++ b/landing/tailwind.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  content: ["./app/**/*.{js,jsx,ts,tsx}"],
+  content: [
+    "./app/**/*.{js,jsx,ts,tsx}",
+    "./components/**/*.{js,jsx,ts,tsx}",
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- enable Tailwind utilities by including `@tailwind` directives in `globals.css`
- expand `tailwind.config.js` content globs to cover a `components` directory

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6852c00fd984832790d1754450a2fc59