### PR TITLE
Enhance lead export options

### DIFF
--- a/backend/src/services/LeadsService/ConsultCepService.ts
+++ b/backend/src/services/LeadsService/ConsultCepService.ts
@@ -53,10 +53,20 @@ const ConsultCepService = async ({ cep, companyId, userId, page }: Request) => {
         queryOrigin: `CEP ${cep}`
       }))
     );
-    return { leads: slice, hasMore: start + PAGE_SIZE < freshLeads.length, credits: balance };
+    return {
+      leads: slice,
+      hasMore: start + PAGE_SIZE < freshLeads.length,
+      credits: balance
+    };
   }
 
-  return { leads: [], hasMore: false, credits: await ConsumeCreditsService(companyId, 0) };
+  const allShown = allLeads.length > 0;
+  return {
+    leads: [],
+    hasMore: false,
+    credits: await ConsumeCreditsService(companyId, 0),
+    allShown
+  };
 };
 
 export default ConsultCepService;


### PR DESCRIPTION
## Summary
- show `allShown` hint when CEP leads already shown
- keep CEP lead history in localStorage and allow reloading
- add dropdown menu with PDF/Loopchat/CSV download options

## Testing
- `npm test` (fails: missing backend database)
- `npm test` in `frontend` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_685745360aa88327a779d86f77b2e740