### PR TITLE
Fix history retrieval and close social login menu

### DIFF
--- a/frontend/src/components/CompanyWhatsapps/index.js
+++ b/frontend/src/components/CompanyWhatsapps/index.js
@@ -451,7 +451,12 @@ const WhatsAppModalCompany = ({
                           scope="public_profile,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagementnt,business_management"
                           callback={responseFacebook}
                           render={renderProps => (
-                            <MenuItem onClick={renderProps.onClick}>
+                            <MenuItem
+                              onClick={() => {
+                                renderProps.onClick();
+                                popupState.close();
+                              }}
+                            >
                               <Facebook
                                 fontSize="small"
                                 style={{
@@ -471,7 +476,12 @@ const WhatsAppModalCompany = ({
                           scope="public_profile,instagram_basic,instagram_manage_messages,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
                           callback={responseInstagram}
                           render={renderProps => (
-                            <MenuItem onClick={renderProps.onClick}>
+                            <MenuItem
+                              onClick={() => {
+                                renderProps.onClick();
+                                popupState.close();
+                              }}
+                            >
                               <Instagram
                                 fontSize="small"
                                 style={{

--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -151,25 +151,26 @@ const Leads = () => {
     }
   }, [results]);
 
-  const handleSearch = async () => {
-    if (!cep || cep.length !== 8) return;
+  const handleSearch = async (searchCep = cep) => {
+    if (!searchCep || searchCep.length !== 8) return;
     if (searchTimeout.current) clearTimeout(searchTimeout.current);
     searchTimeout.current = setTimeout(async () => {
       setLoading(true);
       setTokenError(false);
       try {
-        const { data } = await api.get(`/consult/cep/${cep}?page=1`);
+        const { data } = await api.get(`/consult/cep/${searchCep}?page=1`);
         setResults(data.leads || []);
         if (data.leads && data.leads.length > 0) {
-          localStorage.setItem(`leads_${cep}`, JSON.stringify(data.leads));
+          localStorage.setItem(`leads_${searchCep}`, JSON.stringify(data.leads));
         }
+        setCep(searchCep);
         setPageApi(1);
         setHasMore(data.hasMore);
         if (typeof data.credits === "number") {
           setCredits(data.credits);
         }
         if (!data.leads || data.leads.length === 0) {
-          const stored = localStorage.getItem(`leads_${cep}`);
+          const stored = localStorage.getItem(`leads_${searchCep}`);
           if (data.allShown && stored) {
             toast.info("Todos os leads deste CEP já foram consultados");
             setResults(JSON.parse(stored));
@@ -217,12 +218,14 @@ const Leads = () => {
   };
 
   const handleHistoryClick = (hCep) => {
-    setCep(hCep);
     const stored = localStorage.getItem(`leads_${hCep}`);
     if (stored) {
+      setCep(hCep);
       setResults(JSON.parse(stored));
       setHasMore(false);
       setPageApi(1);
+    } else {
+      handleSearch(hCep);
     }
   };
 


### PR DESCRIPTION
## Summary
- close popup menu after selecting Facebook or Instagram login
- load results when selecting a CEP from history

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` && `npm test` in `backend` *(fails: missing database config)*

------
https://chatgpt.com/codex/tasks/task_e_68574e9ab35483278c133f6aaf5998ae