### PR TITLE
feat: reset cep leads after exhaustion

### DIFF
--- a/backend/src/services/LeadsService/ConsultCepService.ts
+++ b/backend/src/services/LeadsService/ConsultCepService.ts
@@ -36,9 +36,14 @@ const ConsultCepService = async ({ cep, companyId, userId, page }: Request) => {
   });
   const viewedCpfs = viewed.map(v => v.cpf);
 
-  const freshLeads = allLeads.filter(
+  let freshLeads = allLeads.filter(
     (l: any) => !viewedCpfs.includes(l.dados_pessoais.cpf)
   );
+
+  if (freshLeads.length === 0 && page === 1 && allLeads.length > 0) {
+    await LeadView.destroy({ where: { companyId, queryOrigin: `CEP ${cep}` } });
+    freshLeads = allLeads;
+  }
 
   const start = (page - 1) * PAGE_SIZE;
   const slice = freshLeads.slice(start, start + PAGE_SIZE);


### PR DESCRIPTION
## Summary
- reset lead history for a CEP on new search when all leads were already shown

## Testing
- `npm test` *(fails: Cannot find database config)*

------
https://chatgpt.com/codex/tasks/task_e_6857582e049c8327b31132a67385b1bd