### PR TITLE
Skip credit charge when viewing CEP lead details

### DIFF
--- a/backend/src/controllers/ConsultController.ts
+++ b/backend/src/controllers/ConsultController.ts
@@ -21,7 +21,8 @@ export const consultCep = async (req: Request, res: Response): Promise<Response>
 export const consultCpf = async (req: Request, res: Response): Promise<Response> => {
   const { cpf } = req.params;
   const { companyId } = req.user;
+  const fromCep = req.query.from === "cep";
 
-  const result = await ConsultCpfService({ cpf, companyId });
+  const result = await ConsultCpfService({ cpf, companyId, free: fromCep });
   return res.status(200).json(result);
 };

--- a/backend/src/services/LeadsService/ConsultCpfService.ts
+++ b/backend/src/services/LeadsService/ConsultCpfService.ts
@@ -5,9 +5,10 @@ import ConsumeCreditsService from "../CreditService/ConsumeCreditsService";
 interface Request {
   cpf: string;
   companyId: number;
+  free?: boolean;
 }
 
-const ConsultCpfService = async ({ cpf, companyId }: Request) => {
+const ConsultCpfService = async ({ cpf, companyId, free = false }: Request) => {
   const token = process.env.API_TOKEN_CPF;
   if (!token) {
     throw new AppError(
@@ -17,7 +18,7 @@ const ConsultCpfService = async ({ cpf, companyId }: Request) => {
   }
   const url = `https://api.dbconsultas.com/api/v1/${token}/datalinkcpf/${cpf}`;
 
-  const balance = await ConsumeCreditsService(companyId, 3);
+  const balance = await ConsumeCreditsService(companyId, free ? 0 : 3);
 
   try {
     const { data } = await axios.get(url);

--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -305,12 +305,13 @@ const Leads = () => {
     }
   };
 
-  const handleCpf = async (cpf) => {
+  const handleCpf = async (cpf, fromCep = false) => {
     setDetailLoading(true);
     setDetailError("");
     setDetailOpen(true);
     try {
-      const { data } = await api.get(`/consult/cpf/${cpf}`);
+      const url = fromCep ? `/consult/cpf/${cpf}?from=cep` : `/consult/cpf/${cpf}`;
+      const { data } = await api.get(url);
       if (typeof data.credits === "number") {
         setCredits(data.credits);
       }
@@ -531,7 +532,7 @@ const Leads = () => {
                           <TableCell>{item.uf}</TableCell>
                           <TableCell>
                             {item.dados_pessoais.nome}
-                            <IconButton size="small" onClick={() => handleCpf(item.dados_pessoais.cpf)}>
+                            <IconButton size="small" onClick={() => handleCpf(item.dados_pessoais.cpf, true)}>
                               <InfoOutlinedIcon fontSize="small" />
                             </IconButton>
                           </TableCell>


### PR DESCRIPTION
## Summary
- allow ConsultCpfService to skip credit deductions
- flag `from=cep` queries in controller
- mark CPF detail requests from CEP results on the frontend

## Testing
- `npm test` *(fails: Cannot find "/workspace/teste/backend/dist/config/database.js". Have you run "sequelize init"?)*
- `npm test` in `frontend` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68575c0d3d5c8327b6cad01239249f8b