### PR TITLE
Fix isForwarded field mapping

### DIFF
--- a/backend/src/models/Message.ts
+++ b/backend/src/models/Message.ts
@@ -124,7 +124,7 @@ class Message extends Model<Message> {
   isEdited: boolean;
 
   @Default(false)
-  @Column
+  @Column({ field: "isforwarded" })
   isForwarded: boolean;
 }
 


### PR DESCRIPTION
## Summary
- map Message model field `isForwarded` to database column `isforwarded`

## Testing
- `npm test` *(fails: Cannot find `dist/config/database.js`)*
- `npm test` in frontend *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0e40e93c83278bfc6833384ff695