### PR TITLE
Fix message model primary key

### DIFF
--- a/backend/src/models/Message.ts
+++ b/backend/src/models/Message.ts
@@ -19,6 +19,7 @@ import TicketTraking from "./TicketTraking";
 @Table
 class Message extends Model<Message> {
   @PrimaryKey
+  @AutoIncrement
   @Column
   id: number;
 


### PR DESCRIPTION
## Summary
- add `@AutoIncrement` to Message model's ID column

The logs indicated null IDs being inserted into the `Messages` table. The migration `20230704124428-update-messages.ts` expects the ID column to auto increment. The model lacked that configuration, which could lead Sequelize to mis-handle inserts. Adding `@AutoIncrement` aligns the model with the database schema.

## Testing
- `npm test` *(fails: Cannot find `/workspace/teste/backend/dist/config/database.js`)*

------
https://chatgpt.com/codex/tasks/task_e_685a3d73f1fc8327a2837532add31993