### PR TITLE
Fix auto increment for Messages.id

### DIFF
--- a/backend/src/database/migrations/20250701000000-fix-messages-id-default.ts
+++ b/backend/src/database/migrations/20250701000000-fix-messages-id-default.ts
@@ -1,0 +1,22 @@
+import { QueryInterface } from "sequelize";
+
+module.exports = {
+  up: async (queryInterface: QueryInterface) => {
+    // Ensure sequence exists and column id uses it as default
+    await queryInterface.sequelize.query(
+      'CREATE SEQUENCE IF NOT EXISTS "Messages_id_seq"'
+    );
+    await queryInterface.sequelize.query(
+      'ALTER TABLE "Messages" ALTER COLUMN "id" SET DEFAULT nextval(''"Messages_id_seq"''::regclass)'
+    );
+    await queryInterface.sequelize.query(
+      'SELECT setval(''"Messages_id_seq"'', COALESCE((SELECT MAX("id") FROM "Messages"), 0))'
+    );
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.sequelize.query(
+      'ALTER TABLE "Messages" ALTER COLUMN "id" DROP DEFAULT'
+    );
+  }
+};

--- a/backend/src/database/migrations/20250701000000-fix-messages-id-default.ts
+++ b/backend/src/database/migrations/20250701000000-fix-messages-id-default.ts
@@ -7,10 +7,10 @@ module.exports = {
       'CREATE SEQUENCE IF NOT EXISTS "Messages_id_seq"'
     );
     await queryInterface.sequelize.query(
-      'ALTER TABLE "Messages" ALTER COLUMN "id" SET DEFAULT nextval(''"Messages_id_seq"''::regclass)'
+      'ALTER TABLE "Messages" ALTER COLUMN "id" SET DEFAULT nextval(\'"Messages_id_seq"\'::regclass)'
     );
     await queryInterface.sequelize.query(
-      'SELECT setval(''"Messages_id_seq"'', COALESCE((SELECT MAX("id") FROM "Messages"), 0))'
+      'SELECT setval(\'"Messages_id_seq"\', COALESCE((SELECT MAX("id") FROM "Messages"), 0))'
     );
   },
 


### PR DESCRIPTION
## Summary
- ensure `Messages.id` column has a default sequence

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm test` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5c1e4f048327add55d68a75cc1db