### PR TITLE
Fix Message model field name

### DIFF
--- a/backend/src/models/Message.ts
+++ b/backend/src/models/Message.ts
@@ -126,7 +126,7 @@ class Message extends Model<Message> {
   isEdited: boolean;
 
   @Default(false)
-  @Column({ field: "isforwarded" })
+  @Column
   isForwarded: boolean;
 }
 


### PR DESCRIPTION
## Summary
- fix column name mismatch in Message model

## Testing
- `npm test` *(fails: Cannot find "dist/config/database.js")*

------
https://chatgpt.com/codex/tasks/task_e_685ef7195e648327b5d9cd0191801db0