### PR TITLE
Fix null ticket handling

### DIFF
--- a/frontend/src/components/TicketsListCustom/index.js
+++ b/frontend/src/components/TicketsListCustom/index.js
@@ -290,27 +290,24 @@ const TicketsListCustom = (props) => {
                 });
             }
             // console.log(shouldUpdateTicket(data.ticket))
-            if (data.action === "update" &&
-                shouldUpdateTicket(data.ticket) && data.ticket.status === status) {
-                dispatch({
-                    type: "UPDATE_TICKET",
-                    payload: data.ticket,
-                    status: status,
-                    sortDir: sortTickets
-                });
-            }
+            if (data.action === "update" && data.ticket) {
+                if (shouldUpdateTicket(data.ticket) && data.ticket.status === status) {
+                    dispatch({
+                        type: "UPDATE_TICKET",
+                        payload: data.ticket,
+                        status: status,
+                        sortDir: sortTickets
+                    });
+                }
 
-            // else if (data.action === "update" && shouldUpdateTicketUser(data.ticket) && data.ticket.status === status) {
-            //     dispatch({
-            //         type: "UPDATE_TICKET",
-            //         payload: data.ticket,
-            //     });
-            // }
-            if (data.action === "update" && notBelongsToUserQueues(data.ticket)) {
-                dispatch({
-                    type: "DELETE_TICKET", payload: data.ticket?.id, status: status,
-                    sortDir: sortTickets
-                });
+                if (notBelongsToUserQueues(data.ticket)) {
+                    dispatch({
+                        type: "DELETE_TICKET",
+                        payload: data.ticket.id,
+                        status: status,
+                        sortDir: sortTickets
+                    });
+                }
             }
 
             if (data.action === "delete") {
@@ -323,7 +320,7 @@ const TicketsListCustom = (props) => {
         };
 
         const onCompanyAppMessageTicketsList = (data) => {
-            if (data.action === "create" &&
+            if (data.action === "create" && data.ticket &&
                 shouldUpdateTicket(data.ticket) && data.ticket.status === status) {
                 dispatch({
                     type: "UPDATE_TICKET_UNREAD_MESSAGES",


### PR DESCRIPTION
## Summary
- improve null checks in ticket socket updates

## Testing
- `npm test --silent` in frontend (no tests)
- `npm test --silent` in backend *(fails: Cannot find database.js)*

------
https://chatgpt.com/codex/tasks/task_e_685efbf9957483279d2cd1bfcb051fc1