### PR TITLE
Add notifyBeforeDays column

### DIFF
--- a/backend/src/database/migrations/20250702000000-add-notifyBeforeDays-to-schedules.ts
+++ b/backend/src/database/migrations/20250702000000-add-notifyBeforeDays-to-schedules.ts
@@ -1,0 +1,15 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return queryInterface.addColumn("Schedules", "notifyBeforeDays", {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    });
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return queryInterface.removeColumn("Schedules", "notifyBeforeDays");
+  }
+};

--- a/backend/src/models/Schedule.ts
+++ b/backend/src/models/Schedule.ts
@@ -119,6 +119,10 @@ class Schedule extends Model<Schedule> {
   @Column
   contadorEnvio: number;
 
+  @Default(0)
+  @Column
+  notifyBeforeDays: number;
+
   @Default(false)
   @Column
   assinar: boolean;


### PR DESCRIPTION
## Summary
- add `notifyBeforeDays` to Schedule model
- add migration to set default for `notifyBeforeDays`

## Testing
- `npm test` *(fails: Cannot find dist/config/database.js or database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6860f1d89ae08327a2d0c64fcc243203