### PR TITLE
Fix button limit and improve logs

### DIFF
--- a/backend/src/controllers/MessageController.ts
+++ b/backend/src/controllers/MessageController.ts
@@ -74,6 +74,26 @@ export const sendListMessage = async (req: Request, res: Response): Promise<Resp
   const { title, text, buttonText, footer, sections } = req.body;
 
   try {
+    if (!buttonText) {
+      throw new AppError("'buttonText' is required", 400);
+    }
+
+    if (!Array.isArray(sections) || sections.length === 0 || !sections[0].rows || !sections[0].rows.length) {
+      throw new AppError("'sections' with rows is required", 400);
+    }
+
+    const ids = new Set();
+    for (const section of sections) {
+      for (const row of section.rows) {
+        if (!row.rowId) {
+          throw new AppError("rowId is required", 400);
+        }
+        if (ids.has(row.rowId)) {
+          throw new AppError("rowId must be unique", 400);
+        }
+        ids.add(row.rowId);
+      }
+    }
     const ticket = await Ticket.findByPk(ticketId);
 
     if (!ticket) {

--- a/backend/src/services/WbotServices/ChatBotListener.ts
+++ b/backend/src/services/WbotServices/ChatBotListener.ts
@@ -50,6 +50,7 @@ export const deleteAndCreateDialogStage = async (
       queueId: bots.queueId
     });
   } catch (error) {
+    console.error("Erro ao criar diálogo do chatbot:", error);
     await ticket.update({ isBot: false });
   }
 };
@@ -88,6 +89,7 @@ const sendMessageLink = async (
       }
     );
   } catch (error) {
+    console.error("Erro ao enviar PDF:", error);
     sentMessage = await wbot.sendMessage(
       `${contact.number}@${ticket.isGroup ? "g.us" : "s.whatsapp.net"}`,
       {
@@ -118,6 +120,7 @@ const sendMessageImage = async (
       }
     );
   } catch (error) {
+    console.error("Erro ao enviar imagem:", error);
     sentMessage = await wbot.sendMessage(
       `${contact.number}@${ticket.isGroup ? "g.us" : "s.whatsapp.net"}`,
       {
@@ -323,12 +326,20 @@ const sendDialog = async (
 
     const botButton = async () => {
       const buttons = [];
-      showChatBots.options.forEach((option, index) => {
+      if (showChatBots.options.length > 2) {
+        console.warn("Mais de 2 opções, exibindo apenas as 3 primeiras");
+      }
+      showChatBots.options.slice(0, 2).forEach((option, index) => {
         buttons.push({
           buttonId: `${index + 1}`,
           buttonText: { displayText: option.name },
           type: 1
         });
+      });
+      buttons.push({
+        buttonId: "#",
+        buttonText: { displayText: "Voltar Menu Inicial" },
+        type: 1
       });
 
       if (buttons.length > 0) {
@@ -399,11 +410,11 @@ const sendDialog = async (
       return await botText();
     }
 
-    if (typeBot === "button" && showChatBots.options.length > 4) {
+    if (typeBot === "button" && showChatBots.options.length + 1 > 3) {
       return await botText();
     }
 
-    if (typeBot === "button" && showChatBots.options.length <= 4) {
+    if (typeBot === "button") {
       return await botButton();
     }
 

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -1570,7 +1570,7 @@ const verifyQueue = async (
           });
         }
       } catch (error) {
-        logger.info(error);
+        logger.error(error);
       }
     }
 
@@ -1950,7 +1950,7 @@ const verifyQueue = async (
             // debouncedSentMessagePosicao();
           }
         } catch (error) {
-          logger.info(error);
+          logger.error(error);
         }
       }
 
@@ -1969,7 +1969,7 @@ const verifyQueue = async (
             companyId
           });
         } catch (error) {
-          logger.info(error);
+          logger.error(error);
         }
 
         return;
@@ -2312,10 +2312,17 @@ const verifyQueue = async (
             rowId: `${index + 1}`
           });
         });
+
         sectionsRows.push({
           title: "Voltar Menu Inicial",
           rowId: "#"
         });
+
+        const hasRows = sectionsRows.length > 0;
+        const idSet = new Set(sectionsRows.map(r => r.rowId));
+        if (idSet.size !== sectionsRows.length) {
+          logger.warn("rowId duplicado em botList");
+        }
         const sections = [
           {
             title: 'Lista de Botões',
@@ -2327,10 +2334,13 @@ const verifyQueue = async (
           text: formatBody(`\u200e${queue.greetingMessage}\n`),
           title: "Lista\n",
           buttonText: "Clique aqui",
-          //footer: ".",
-          //listType: 2,
           sections
-        };
+        } as any;
+
+        if (!listMessage.buttonText || !hasRows) {
+          logger.error("Estrutura de lista inválida");
+          return;
+        }
         const sendMsg = await wbot.sendMessage(
           `${ticket.contact.number}@${ticket.isGroup ? "g.us" : "s.whatsapp.net"}`,
           listMessage
@@ -2402,7 +2412,7 @@ const verifyQueue = async (
 
 
         } catch (error) {
-          logger.info(error);
+          logger.error(error);
         }
       }
 
@@ -2423,7 +2433,7 @@ const verifyQueue = async (
             companyId,
           });
         } catch (error) {
-          logger.info(error);
+          logger.error(error);
         }
 
         return;
@@ -2775,10 +2785,14 @@ const verifyQueue = async (
 
               const buttons = [];
 
-              // Adiciona os chatbots como botões
-              choosenQueue.chatbots.forEach((chatbot, index) => {
+              if (choosenQueue.chatbots.length > 2) {
+                logger.warn("Mais de 2 chatbots encontrados, limitando botões a 3");
+              }
+
+              // Adiciona no máximo dois chatbots como botões
+              choosenQueue.chatbots.slice(0, 2).forEach((chatbot, index) => {
                 buttons.push({
-                  name: 'quick_reply',  // Substitua por 'quick_reply' se necessário, dependendo do contexto
+                  name: 'quick_reply',
                   buttonParamsJson: JSON.stringify({
                     display_text: chatbot.name,
                     id: `${index + 1}`
@@ -2890,7 +2904,7 @@ const verifyQueue = async (
 
 
         } catch (error) {
-          logger.info(error);
+          logger.error(error);
         }
       }
 
@@ -2911,7 +2925,7 @@ const verifyQueue = async (
             companyId,
           });
         } catch (error) {
-          logger.info(error);
+          logger.error(error);
         }
 
         return;
@@ -3274,17 +3288,17 @@ const verifyQueue = async (
   if (typeBot === "text") {
     return botText();
   }
-  
-   if (typeBot === "list") {
+
+  if (typeBot === "list") {
+    return botList();
+  }
+
+  if (typeBot === "button" && queues.length > 3) {
     return botList();
   }
 
   if (typeBot === "button") {
     return botButton();
-  }
-
-  if (typeBot === "button" && queues.length > 3) {
-    return botText();
   }
 };
 


### PR DESCRIPTION
## Summary
- handle missing parameters for interactive list messages
- add error logging in chatbot helper functions
- limit WhatsApp buttons to max of 3 options
- validate rows when sending list messages
- fallback to list when there are too many queues

## Testing
- `npm install` *(fails: eslint, sequelize, other packages installed)*
- `npm test` *(fails: Cannot find database config)*

------
https://chatgpt.com/codex/tasks/task_e_68647c58b5a08327abf96ed11cdb67ad