### PR TITLE
Add tokens for Work API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ variáveis `FACEBOOK_APP_ID` e `FACEBOOK_APP_SECRET` no backend. O frontend usa
 os mesmos em ambos os projetos para que o login via Facebook e Instagram
 funcione corretamente.
 
+Para habilitar as consultas de CEP e CPF pela Work API, defina também no backend
+as variáveis `API_TOKEN_CEP` e `API_TOKEN_CPF`. O frontend possui as variáveis
+`REACT_APP_API_TOKEN_CEP` e `REACT_APP_API_TOKEN_CPF`, utilizadas apenas para
+mensagens de aviso ao usuário.
+
 ## Executando o backend
 
 Na pasta `backend` estão disponíveis os seguintes scripts:

--- a/backend/.env.exemple
+++ b/backend/.env.exemple
@@ -75,3 +75,7 @@ MAIL_PASS="SuaSenha"
 MAIL_FROM="seu@gmail.com"
 MAIL_PORT="465"
 ADMIN_PHONE=
+
+# Tokens da Work API para consultas de CEP e CPF
+API_TOKEN_CEP=
+API_TOKEN_CPF=


### PR DESCRIPTION
## Summary
- document environment variables needed for CEP/CPF lookups
- update backend env example with API_TOKEN_CEP and API_TOKEN_CPF

## Testing
- `npm test` (backend) *(fails: Cannot find dist/config/database.js)*
- `npm test -- -w=1` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68649cee21b48327852c3564f14ae97f