### PR TITLE
Fix missing phone fields in CPF consult

### DIFF
--- a/frontend/src/helpers/normalizeCpfDetail.js
+++ b/frontend/src/helpers/normalizeCpfDetail.js
@@ -68,7 +68,11 @@ export default function normalizeCpfDetail(detail) {
   // merge celulares array into telefones if needed
   let phones = [];
   if (Array.isArray(normalized.telefones)) {
-    phones = normalized.telefones;
+    phones = normalized.telefones.map((tel) => ({
+      numero: tel.numero || tel.telefone || "",
+      tipo: tel.tipo || tel.operadora || "",
+      whatsapp: tel.whatsapp || false,
+    }));
   }
   if (Array.isArray(normalized.celulares)) {
     phones = phones.concat(


### PR DESCRIPTION
## Summary
- normalize phone fields returned by CPF API so the leads page displays them

## Testing
- `npm test` *(backend)*
- `npm test -- -w 1` *(frontend)*

------
https://chatgpt.com/codex/tasks/task_e_6865341252948327aa96c046e42a882e