### PR TITLE
Fix leads page blank fields

### DIFF
--- a/frontend/src/helpers/normalizeLeadItem.js
+++ b/frontend/src/helpers/normalizeLeadItem.js
@@ -1,0 +1,59 @@
+export default function normalizeLeadItem(item) {
+  if (!item || typeof item !== "object") {
+    return item;
+  }
+
+  let lead = item;
+
+  if (lead.data && !lead.dados_pessoais && !lead.dados_basicos) {
+    lead = lead.data;
+  }
+
+  if (lead.dados_basicos && !lead.dados_pessoais) {
+    const basics = lead.dados_basicos;
+    lead.dados_pessoais = {
+      cpf: basics.cpf,
+      nome: basics.nome,
+      nome_mae: basics.nome_mae,
+      nome_pai: basics.nome_pai,
+      nasc: basics.nascimento,
+      sexo: basics.sexo,
+      renda: basics.renda || basics.renda_presumida,
+      faixa_renda: basics.faixa_renda_id,
+      cbo: basics.cbo,
+    };
+  }
+
+  if (!lead.dados_pessoais && lead.cpf) {
+    lead.dados_pessoais = {
+      cpf: lead.cpf,
+      nome: lead.nome,
+      nome_mae: lead.nome_mae,
+      nome_pai: lead.nome_pai,
+      nasc: lead.nasc || lead.data_nascimento,
+      sexo: lead.sexo,
+      renda: lead.renda,
+      faixa_renda: lead.faixa_renda_id,
+      cbo: lead.cbo,
+    };
+  }
+
+  if (!Array.isArray(lead.enderecos)) {
+    const addr =
+      lead.endereco ||
+      lead.endereco_residencial ||
+      (typeof lead.enderecos === "object" ? lead.enderecos : null);
+    lead.enderecos = addr ? [addr] : [];
+  }
+
+  if (!lead.logradouro && Array.isArray(lead.enderecos) && lead.enderecos[0]) {
+    const addr = lead.enderecos[0];
+    lead.logradouro = addr.logradouro || addr.endereco || "";
+    lead.numero = addr.numero;
+    lead.bairro = addr.bairro;
+    lead.cidade = addr.cidade;
+    lead.uf = addr.uf;
+  }
+
+  return lead;
+}

--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -30,6 +30,7 @@ import { toast } from "react-toastify";
 import moment from "moment";
 import LeadDetailModal from "../../components/LeadDetailModal";
 import normalizeCpfDetail from "../../helpers/normalizeCpfDetail";
+import normalizeLeadItem from "../../helpers/normalizeLeadItem";
 import usePlans from "../../hooks/usePlans";
 import { AuthContext } from "../../context/Auth/AuthContext";
 
@@ -130,7 +131,8 @@ const Leads = () => {
   useEffect(() => {
     const stored = localStorage.getItem("leadsResults");
     if (stored) {
-      setResults(JSON.parse(stored));
+      const parsed = JSON.parse(stored).map(normalizeLeadItem);
+      setResults(parsed);
     }
     const hist = JSON.parse(localStorage.getItem("leadsHistory") || "[]");
     setHistory(hist);
@@ -159,9 +161,10 @@ const Leads = () => {
     setTokenError(false);
     try {
       const { data } = await api.get(`/consult/cep/${searchCep}?page=1`);
-      setResults(data.leads || []);
-      if (data.leads && data.leads.length > 0) {
-        localStorage.setItem(`leads_${searchCep}`, JSON.stringify(data.leads));
+      const leads = (data.leads || []).map(normalizeLeadItem);
+      setResults(leads);
+      if (leads.length > 0) {
+        localStorage.setItem(`leads_${searchCep}`, JSON.stringify(leads));
       }
       setCep(searchCep);
       setPageApi(1);
@@ -222,7 +225,8 @@ const Leads = () => {
     const stored = localStorage.getItem(`leads_${hCep}`);
     if (stored) {
       setCep(hCep);
-      setResults(JSON.parse(stored));
+      const parsed = JSON.parse(stored).map(normalizeLeadItem);
+      setResults(parsed);
       setHasMore(false);
       setPageApi(1);
     } else {
@@ -289,7 +293,8 @@ const Leads = () => {
     setLoadingMore(true);
     try {
       const { data } = await api.get(`/consult/cep/${cep}?page=${next}`);
-      setResults((prev) => [...prev, ...(data.leads || [])]);
+      const leads = (data.leads || []).map(normalizeLeadItem);
+      setResults((prev) => [...prev, ...leads]);
       setHasMore(data.hasMore);
       if (typeof data.credits === "number") {
         setCredits(data.credits);


### PR DESCRIPTION
## Summary
- normalize leads list entries so data fields don't appear blank
- store normalized leads in localStorage
- update search/loadmore/history handlers to normalize API results
- handle alternate address formats when normalizing leads

## Testing
- `npm test` (fails: sequelize not found)
- `npm test --silent` in frontend (fails: react-scripts not found)

------
https://chatgpt.com/codex/tasks/task_e_6865388028cc8327bb70487defbe5001