### PR TITLE
Fix lead detail score

### DIFF
--- a/frontend/src/helpers/normalizeCpfDetail.js
+++ b/frontend/src/helpers/normalizeCpfDetail.js
@@ -102,6 +102,11 @@ export default function normalizeCpfDetail(detail) {
   if (!normalized.avaliacao_score) {
     if (normalized.avalicao_score) {
       normalized.avaliacao_score = normalized.avalicao_score;
+    } else if (normalized.dados_score) {
+      normalized.avaliacao_score = {
+        csba: normalized.dados_score.score,
+        csba_faixa: normalized.dados_score.faixa_risco,
+      };
     } else {
       normalized.avaliacao_score = normalized.score || {};
     }

--- a/frontend/src/helpers/normalizeLeadItem.js
+++ b/frontend/src/helpers/normalizeLeadItem.js
@@ -55,5 +55,18 @@ export default function normalizeLeadItem(item) {
     lead.uf = addr.uf;
   }
 
+  if (!lead.avaliacao_score) {
+    if (lead.avalicao_score) {
+      lead.avaliacao_score = lead.avalicao_score;
+    } else if (lead.dados_score) {
+      lead.avaliacao_score = {
+        csba: lead.dados_score.score,
+        csba_faixa: lead.dados_score.faixa_risco,
+      };
+    } else {
+      lead.avaliacao_score = lead.score || {};
+    }
+  }
+
   return lead;
 }


### PR DESCRIPTION
## Summary
- map `dados_score` from API to `avaliacao_score`

## Testing
- `npm test --silent --prefix frontend`
- `npm test --silent --prefix backend` *(fails: Cannot find "dist/config/database.js")*

------
https://chatgpt.com/codex/tasks/task_e_6865983ff1008327a2a584ee79d5ea70