### PR TITLE
Fix CEP search click handling

### DIFF
--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -382,7 +382,7 @@ const Leads = () => {
         <Button
           variant="contained"
           color="primary"
-          onClick={handleSearch}
+          onClick={() => handleSearch()}
           startIcon={!loading && <SearchIcon />}
           disabled={loading}
         >


### PR DESCRIPTION
## Summary
- ensure CEP search button doesn't pass click event to handler

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659b34eac483278d93a99accbc26f2