### PR TITLE
Fix poder_aquisitivo normalization

### DIFF
--- a/frontend/src/helpers/normalizeCpfDetail.js
+++ b/frontend/src/helpers/normalizeCpfDetail.js
@@ -129,13 +129,16 @@ export default function normalizeCpfDetail(detail) {
       : "Não";
   }
 
-  if (!normalized.poder_aquisitivo && normalized.poder_aquisitivo !== undefined) {
+  if (normalized.poder_aquisitivo && typeof normalized.poder_aquisitivo === "object") {
     normalized.poder_aquisitivo = {
       cod_poder_aquisitivo: normalized.poder_aquisitivo.cod_poder_aquisitivo,
       poder_aquisitivo: normalized.poder_aquisitivo.poder_aquisitivo,
-      renda_poder_aquisitivo: normalized.poder_aquisitivo.renda_poder_aquisitivo,
+      renda_poder_aquisitivo:
+        normalized.poder_aquisitivo.renda_poder_aquisitivo,
       fx_poder_aquisitivo: normalized.poder_aquisitivo.fx_poder_aquisitivo,
     };
+  } else {
+    normalized.poder_aquisitivo = {};
   }
 
   if (!normalized.fgts) {


### PR DESCRIPTION
## Summary
- fix poder_aquisitivo normalization logic in normalizeCpfDetail helper

## Testing
- `npm test` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a6a60ea08327b788a62252a7eb36