### PR TITLE
Add Painel TV menu item

### DIFF
--- a/frontend/src/layout/MainListItems.js
+++ b/frontend/src/layout/MainListItems.js
@@ -25,6 +25,7 @@ import FlashOnIcon from "@material-ui/icons/FlashOn";
 import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
 import CodeRoundedIcon from "@material-ui/icons/CodeRounded";
 import ViewKanban from "@mui/icons-material/ViewKanban";
+import LiveTvIcon from "@mui/icons-material/LiveTv";
 import Schedule from "@material-ui/icons/Schedule";
 import LocalOfferIcon from "@material-ui/icons/LocalOffer";
 import EventAvailableIcon from "@material-ui/icons/EventAvailable";
@@ -454,15 +455,27 @@ const MainListItems = ({ collapsed, drawerClose }) => {
                 )}
               />
               <Can
-                role={user.profile === "user" && user.allowRealTime === "enabled" ? "admin" : user.profile}
+                role={
+                  user.profile === "user" && user.allowRealTime === "enabled"
+                    ? "admin"
+                    : user.profile
+                }
                 perform={"drawer-admin-items:view"}
                 yes={() => (
-                  <ListItemLink
-                    to="/moments"
-                    primary={i18n.t("mainDrawer.listItems.chatsTempoReal")}
-                    icon={<GridOn />}
-                    tooltip={collapsed}
-                  />
+                  <>
+                    <ListItemLink
+                      to="/moments"
+                      primary={i18n.t("mainDrawer.listItems.chatsTempoReal")}
+                      icon={<GridOn />}
+                      tooltip={collapsed}
+                    />
+                    <ListItemLink
+                      to="/painel-tv"
+                      primary={i18n.t("mainDrawer.listItems.painelTV")}
+                      icon={<LiveTvIcon />}
+                      tooltip={collapsed}
+                    />
+                  </>
                 )}
               />
             </Collapse>

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -250,8 +250,9 @@ const messages = {
 			mainDrawer: {
 				listItems: {
 					dashboard: "Dashboard",
-					connections: "Connections",
-					tickets: "Tickets",
+                                        connections: "Connections",
+                                        painelTV: "TV Panel",
+                                        tickets: "Tickets",
 					contacts: "Contacts",
 					queues: "Queues",
 					administration: "Administration",

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -847,6 +847,7 @@ const messages = {
           dashboard: "Dashboard",
           connections: "Conexiones",
           chatsTempoReal: "Panel de Asistencia",
+          painelTV: "Panel TV",
           tickets: "Inbox",
           quickMessages: "Respuestas Rápidas",
           contacts: "Contactos",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -871,6 +871,7 @@ const messages = {
           dashboard: "Dashboard",
           connections: "Conexões",
           chatsTempoReal: "Painel",
+          painelTV: "Painel TV",
           tickets: "Atendimentos",
           quickMessages: "Respostas rápidas",
           contacts: "Contatos",


### PR DESCRIPTION
## Summary
- add Painel TV item to main menu
- include Live TV icon
- add translations for Portuguese, Spanish and English

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: could not resolve dependency framer-motion)*

------
https://chatgpt.com/codex/tasks/task_e_6865e83ec7fc8327bbd6282e820089a4