### PR TITLE
Improve real-time panel waiting view

### DIFF
--- a/frontend/src/components/PainelTV/ActiveTickets.tsx
+++ b/frontend/src/components/PainelTV/ActiveTickets.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { Avatar, Box, Grid, Paper, Typography } from "@mui/material";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import { motion, AnimatePresence } from "framer-motion";
+import GroupedTickets from "./GroupedTickets";
+
+interface Group {
+  user: any;
+  tickets: any[];
+}
+
+interface ActiveTicketsProps {
+  groups: Group[];
+}
+
+const ActiveTickets: React.FC<ActiveTicketsProps> = ({ groups }) => {
+  const total = groups.reduce((acc, g) => acc + g.tickets.length, 0);
+  return (
+    <Paper variant="outlined" sx={{ p: 1 }} component={motion.div} layout>
+      <Box display="flex" alignItems="center" mb={1}>
+        <Avatar sx={{ mr: 1 }}>
+          <CheckCircleIcon color="success" />
+        </Avatar>
+        <Box>
+          <Typography variant="subtitle1">Em Atendimento</Typography>
+          <Typography variant="caption">Atendimentos: {total}</Typography>
+        </Box>
+      </Box>
+      <Grid container spacing={1} alignItems="flex-start">
+        <AnimatePresence>
+          {groups.map((group) => (
+            <Grid item xs={12} sm={6} md={4} key={group.user.id}>
+              <GroupedTickets user={group.user} tickets={group.tickets} />
+            </Grid>
+          ))}
+        </AnimatePresence>
+      </Grid>
+    </Paper>
+  );
+};
+
+export default ActiveTickets;

--- a/frontend/src/components/PainelTV/PendingTickets.tsx
+++ b/frontend/src/components/PainelTV/PendingTickets.tsx
@@ -16,11 +16,15 @@ const PendingTickets: React.FC<PendingTicketsProps> = ({ tickets }) => {
           <ReportProblemIcon color="warning" />
         </Avatar>
         <Box>
-          <Typography variant="subtitle1">Pendentes</Typography>
+          <Typography variant="subtitle1">Aguardando</Typography>
           <Typography variant="caption">Atendimentos: {tickets.length}</Typography>
         </Box>
       </Box>
-      <AnimatePresence>{tickets.map((t) => <TicketCard key={t.id} ticket={t} />)}</AnimatePresence>
+      <AnimatePresence>
+        {tickets.map((t) => (
+          <TicketCard key={t.id} ticket={t} showWaitingTime />
+        ))}
+      </AnimatePresence>
     </Paper>
   );
 };

--- a/frontend/src/components/PainelTV/TicketCard.tsx
+++ b/frontend/src/components/PainelTV/TicketCard.tsx
@@ -5,10 +5,36 @@ import { motion } from "framer-motion";
 
 interface TicketCardProps {
   ticket: any;
+  showWaitingTime?: boolean;
 }
 
-const TicketCard: React.FC<TicketCardProps> = ({ ticket }) => {
+const TicketCard: React.FC<TicketCardProps> = ({ ticket, showWaitingTime }) => {
   const lastUpdate = parseISO(ticket.updatedAt);
+  const createdAt = parseISO(ticket.createdAt);
+  const [elapsed, setElapsed] = React.useState<number>(() =>
+    Math.floor((Date.now() - createdAt.getTime()) / 1000)
+  );
+
+  React.useEffect(() => {
+    if (!showWaitingTime) return;
+    const interval = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - createdAt.getTime()) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [createdAt, showWaitingTime]);
+
+  const formatElapsed = () => {
+    const hours = Math.floor(elapsed / 3600)
+      .toString()
+      .padStart(2, "0");
+    const minutes = Math.floor((elapsed % 3600) / 60)
+      .toString()
+      .padStart(2, "0");
+    const seconds = Math.floor(elapsed % 60)
+      .toString()
+      .padStart(2, "0");
+    return `${hours}:${minutes}:${seconds}`;
+  };
 
   return (
     <motion.div layout initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.95 }}>
@@ -34,9 +60,18 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket }) => {
             )}
           </Box>
         </Box>
-        <Typography variant="caption" color="text.secondary">
-          {isSameDay(lastUpdate, new Date()) ? format(lastUpdate, "HH:mm") : format(lastUpdate, "dd/MM")}
-        </Typography>
+        <Box textAlign="right">
+          <Typography variant="caption" color="text.secondary">
+            {isSameDay(lastUpdate, new Date())
+              ? format(lastUpdate, "HH:mm")
+              : format(lastUpdate, "dd/MM")}
+          </Typography>
+          {showWaitingTime && (
+            <Typography variant="caption" color="error.main">
+              {formatElapsed()}
+            </Typography>
+          )}
+        </Box>
       </Box>
     </motion.div>
   );

--- a/frontend/src/pages/PainelTV.tsx
+++ b/frontend/src/pages/PainelTV.tsx
@@ -3,9 +3,8 @@ import { Container, Grid, Typography } from "@mui/material";
 import { useQuery, useQueryClient } from "react-query";
 import { AuthContext } from "../context/Auth/AuthContext";
 import api from "../services/api";
-import GroupedTickets from "../components/PainelTV/GroupedTickets";
 import PendingTickets from "../components/PainelTV/PendingTickets";
-import { AnimatePresence } from "framer-motion";
+import ActiveTickets from "../components/PainelTV/ActiveTickets";
 
 interface Ticket {
   id: number;
@@ -60,18 +59,16 @@ const PainelTV: React.FC = () => {
         📺 Painel de Atendimentos em Tempo Real
       </Typography>
       <Grid container spacing={2} alignItems="flex-start">
-        <AnimatePresence>
-          {grouped.map((group) => (
-            <Grid item xs={12} sm={6} md={4} key={group.user.id}>
-              <GroupedTickets user={group.user} tickets={group.tickets} />
-            </Grid>
-          ))}
-          {pending.length > 0 && (
-            <Grid item xs={12} sm={6} md={4} key="pending">
-              <PendingTickets tickets={pending} />
-            </Grid>
-          )}
-        </AnimatePresence>
+        {pending.length > 0 && (
+          <Grid item xs={12} md={4} key="pending">
+            <PendingTickets tickets={pending} />
+          </Grid>
+        )}
+        {grouped.length > 0 && (
+          <Grid item xs={12} md={8} key="active">
+            <ActiveTickets groups={grouped} />
+          </Grid>
+        )}
       </Grid>
     </Container>
   );


### PR DESCRIPTION
## Summary
- show waiting timer for pending tickets
- rename pending box to "Aguardando"
- wrap active tickets in a new container
- update PainelTV layout with new boxes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ef414e788327a86bd24adea9ca6e