### PR TITLE
Fix Facebook login initialization

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -102,17 +102,6 @@
         <div id="root"></div>
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <div id="root"></div>
-        <script>
-                window.fbAsyncInit = function() {
-                        FB.init({
-                                appId      : '%REACT_APP_FACEBOOK_APP_ID%',
-                                cookie     : true,
-                                xfbml      : true,
-                                version    : 'v%REACT_APP_FACEBOOK_API_VERSION%'
-                        });
-                };
-        </script>
-        <script async defer crossorigin="anonymous" src="https://connect.facebook.net/pt_BR/sdk.js"></script>
 	<script>
 		// Simulate progress update
 		progress = 0;


### PR DESCRIPTION
## Summary
- remove manual FB.init and SDK injection so library handles initialization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68680aace2908327a85236df9e950f11