### PR TITLE
Add configurable Facebook redirect URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ As credenciais do aplicativo Meta (Facebook/Instagram) devem ser definidas nas
 variáveis `FACEBOOK_APP_ID` e `FACEBOOK_APP_SECRET` no backend. O frontend usa
 `REACT_APP_FACEBOOK_APP_ID` para inicializar o SDK. Utilize também a variável
 `FACEBOOK_API_VERSION` (no backend) e `REACT_APP_FACEBOOK_API_VERSION` (no
-frontend) para definir a versão da Graph API utilizada. Esses valores precisam
-ser os mesmos em ambos os projetos para que o login via Facebook e Instagram
-funcione corretamente.
+frontend) para definir a versão da Graph API utilizada. Caso a aplicação
+utilize redirecionamento explícito, defina `REACT_APP_FACEBOOK_REDIRECT_URI`
+no frontend com a mesma URL cadastrada nas configurações do app. Esses valores
+precisam ser os mesmos em ambos os projetos para que o login via Facebook e
+Instagram funcione corretamente.
 
 Para habilitar as consultas de CEP e CPF pela Work API, defina também no backend
 as variáveis `API_TOKEN_CEP` e `API_TOKEN_CPF`. O frontend possui as variáveis

--- a/frontend/.env.exemple
+++ b/frontend/.env.exemple
@@ -11,6 +11,7 @@ REACT_APP_FACEBOOK_APP_ID=
 FACEBOOK_APP_ID=
 FACEBOOK_APP_SECRET=
 REACT_APP_FACEBOOK_API_VERSION=20.0
+REACT_APP_FACEBOOK_REDIRECT_URI=
 # Token utilizado para consultas de CEP na Work API
 REACT_APP_API_TOKEN_CEP=seu_token_cep
 # Token utilizado para consultas de CPF na Work API

--- a/frontend/src/components/CompanyWhatsapps/index.js
+++ b/frontend/src/components/CompanyWhatsapps/index.js
@@ -449,6 +449,7 @@ const WhatsAppModalCompany = ({
                           fields="name,email,picture"
                           version={process.env.REACT_APP_FACEBOOK_API_VERSION}
                           scope="public_profile,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagementnt,business_management"
+                          dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
                           onSuccess={responseFacebook}
                           render={({ onClick }) => (
                             <MenuItem
@@ -474,6 +475,7 @@ const WhatsAppModalCompany = ({
                           fields="name,email,picture"
                           version={process.env.REACT_APP_FACEBOOK_API_VERSION}
                           scope="public_profile,instagram_basic,instagram_manage_messages,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
+                          dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
                           onSuccess={responseInstagram}
                           render={({ onClick }) => (
                             <MenuItem

--- a/frontend/src/pages/AllConnections/index.js
+++ b/frontend/src/pages/AllConnections/index.js
@@ -471,6 +471,7 @@ const AllConnections = () => {
                           fields="name,email,picture"
                           version={process.env.REACT_APP_FACEBOOK_API_VERSION}
                           scope="public_profile,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
+                          dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
                           onSuccess={responseFacebook}
                           render={({ onClick }) => (
                             <MenuItem onClick={onClick}>
@@ -491,6 +492,7 @@ const AllConnections = () => {
                           fields="name,email,picture"
                           version={process.env.REACT_APP_FACEBOOK_API_VERSION}
                           scope="public_profile,instagram_basic,instagram_manage_messages,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
+                          dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
                           onSuccess={responseInstagram}
                           render={({ onClick }) => (
                             <MenuItem onClick={onClick}>

--- a/frontend/src/pages/Connections/index.js
+++ b/frontend/src/pages/Connections/index.js
@@ -632,6 +632,7 @@ const Connections = () => {
                               fields="name,email,picture"
                               version={process.env.REACT_APP_FACEBOOK_API_VERSION}
                               scope="public_profile,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
+                              dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
                               onSuccess={responseFacebook}
                               render={({ onClick }) => (
                                 <MenuItem
@@ -656,6 +657,7 @@ const Connections = () => {
                               fields="name,email,picture"
                               version={process.env.REACT_APP_FACEBOOK_API_VERSION}
                               scope="public_profile,instagram_basic,instagram_manage_messages,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
+                              dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
                               onSuccess={responseInstagram}
                               render={({ onClick }) => (
                                 <MenuItem


### PR DESCRIPTION
## Summary
- support custom Facebook redirect URL via `REACT_APP_FACEBOOK_REDIRECT_URI`
- add docs and env example for the new variable
- pass `dialogParams` to the `FacebookLogin` components

## Testing
- `npm test` in `backend` *(fails: Cannot find "/workspace/teste/backend/dist/config/database.js")*
- `npm test -- -w 1` in `frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_686b15d4af448327ae349d142bfc5832