### PR TITLE
Hide Facebook and Instagram connections

### DIFF
--- a/frontend/src/pages/AllConnections/index.js
+++ b/frontend/src/pages/AllConnections/index.js
@@ -465,47 +465,25 @@ const AllConnections = () => {
                           />
                           WhatsApp
                         </MenuItem>
-                        <FacebookLogin
-                          appId={process.env.REACT_APP_FACEBOOK_APP_ID}
-                          autoLoad={false}
-                          fields="name,email,picture"
-                          version={process.env.REACT_APP_FACEBOOK_API_VERSION}
-                          scope="public_profile,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
-                          dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
-                          onSuccess={responseFacebook}
-                          render={({ onClick }) => (
-                            <MenuItem onClick={onClick}>
-                              <Facebook
-                                fontSize="small"
-                                style={{
-                                  marginRight: "10px"
-                                }}
-                              />
-                              Facebook
-                            </MenuItem>
-                          )}
-                        />
+                          <MenuItem disabled>
+                            <Facebook
+                              fontSize="small"
+                              style={{
+                                marginRight: "10px"
+                              }}
+                            />
+                            Facebook (em manutenção)
+                          </MenuItem>
 
-                        <FacebookLogin
-                          appId={process.env.REACT_APP_FACEBOOK_APP_ID}
-                          autoLoad={false}
-                          fields="name,email,picture"
-                          version={process.env.REACT_APP_FACEBOOK_API_VERSION}
-                          scope="public_profile,instagram_basic,instagram_manage_messages,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
-                          dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
-                          onSuccess={responseInstagram}
-                          render={({ onClick }) => (
-                            <MenuItem onClick={onClick}>
-                              <Instagram
-                                fontSize="small"
-                                style={{
-                                  marginRight: "10px"
-                                }}
-                              />
-                              Instagram
-                            </MenuItem>
-                          )}
-                        />
+                          <MenuItem disabled>
+                            <Instagram
+                              fontSize="small"
+                              style={{
+                                marginRight: "10px"
+                              }}
+                            />
+                            Instagram (em manutenção)
+                          </MenuItem>
                       </Menu>
                     </React.Fragment>
                   )}

--- a/frontend/src/pages/Connections/index.js
+++ b/frontend/src/pages/Connections/index.js
@@ -626,55 +626,27 @@ const Connections = () => {
                               WhatsApp
                             </MenuItem>
                             {/* FACEBOOK */}
-                            <FacebookLogin
-                              appId={process.env.REACT_APP_FACEBOOK_APP_ID}
-                              autoLoad={false}
-                              fields="name,email,picture"
-                              version={process.env.REACT_APP_FACEBOOK_API_VERSION}
-                              scope="public_profile,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
-                              dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
-                              onSuccess={responseFacebook}
-                              render={({ onClick }) => (
-                                <MenuItem
-                                  disabled={planConfig?.plan?.useFacebook ? false : true}
-                                  onClick={onClick}
-                                >
-                                  <Facebook
-                                    fontSize="small"
-                                    style={{
-                                      marginRight: "10px",
-                                      color: "#3b5998",
-                                    }}
-                                  />
-                                  Facebook
-                                </MenuItem>
-                              )}
-                            />
+                            <MenuItem disabled>
+                              <Facebook
+                                fontSize="small"
+                                style={{
+                                  marginRight: "10px",
+                                  color: "#3b5998",
+                                }}
+                              />
+                              Facebook (em manutenção)
+                            </MenuItem>
                             {/* INSTAGRAM */}
-                            <FacebookLogin
-                              appId={process.env.REACT_APP_FACEBOOK_APP_ID}
-                              autoLoad={false}
-                              fields="name,email,picture"
-                              version={process.env.REACT_APP_FACEBOOK_API_VERSION}
-                              scope="public_profile,instagram_basic,instagram_manage_messages,pages_messaging,pages_show_list,pages_manage_metadata,pages_read_engagement,business_management"
-                              dialogParams={{ redirect_uri: process.env.REACT_APP_FACEBOOK_REDIRECT_URI }}
-                              onSuccess={responseInstagram}
-                              render={({ onClick }) => (
-                                <MenuItem
-                                  disabled={planConfig?.plan?.useInstagram ? false : true}
-                                  onClick={onClick}
-                                >
-                                  <Instagram
-                                    fontSize="small"
-                                    style={{
-                                      marginRight: "10px",
-                                      color: "#e1306c",
-                                    }}
-                                  />
-                                  Instagram
-                                </MenuItem>
-                              )}
-                            />
+                            <MenuItem disabled>
+                              <Instagram
+                                fontSize="small"
+                                style={{
+                                  marginRight: "10px",
+                                  color: "#e1306c",
+                                }}
+                              />
+                              Instagram (em manutenção)
+                            </MenuItem>
                           </Menu>
                         </>
                       )}


### PR DESCRIPTION
## Summary
- update connection menu to show Facebook and Instagram as under maintenance
- update all connections page similarly

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686b623d723c83279635fcc8effaa362