### PR TITLE
Improve whatsapp session check

### DIFF
--- a/backend/src/helpers/EnsureWbotSession.ts
+++ b/backend/src/helpers/EnsureWbotSession.ts
@@ -9,12 +9,13 @@ type Session = WASocket & {
 const EnsureWbotSession = (input: Whatsapp | Session): Session => {
   const wbot = ("ws" in input ? (input as Session) : getWbot(input.id));
 
-  if (
-    !wbot ||
-    !wbot.ws ||
-    ((wbot.ws as any).readyState !== "open" && (wbot.ws as any).readyState !== 1) ||
-    !wbot.user
-  ) {
+  const readyState = (wbot?.ws as any)?.readyState;
+  const isOpen =
+    readyState === "open" ||
+    readyState === "OPEN" ||
+    readyState === 1;
+
+  if (!wbot || !wbot.ws || !isOpen || !wbot.user) {
     throw new AppError("ERR_WAPP_SESSION_NOT_READY");
   }
 


### PR DESCRIPTION
## Summary
- handle both numerical and string WebSocket ready states when ensuring session

## Testing
- `npm test` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0b5b3b4483279a658a5bc83ef147