### PR TITLE
Fix EnsureWbotSession parameter

### DIFF
--- a/backend/src/helpers/EnsureWbotSession.ts
+++ b/backend/src/helpers/EnsureWbotSession.ts
@@ -1,15 +1,18 @@
-import { getWbot } from "../libs/wbot";
-import Whatsapp from "../models/Whatsapp";
+import { WASocket } from "@whiskeysockets/baileys";
 import AppError from "../errors/AppError";
 
-const EnsureWbotSession = (whatsapp: Whatsapp) => {
-  const wbot = getWbot(whatsapp.id);
+const EnsureWbotSession = (wbot: WASocket) => {
 
   // wbot.ws.readyState follows the WebSocket ready state numeric enum.
   // 1 corresponds to an open connection.
   const READY_STATE_OPEN = 1;
 
-  if (!wbot || !wbot.ws || wbot.ws.readyState !== READY_STATE_OPEN || !wbot.user) {
+  if (
+    !wbot ||
+    !wbot.ws ||
+    (wbot.ws as any).readyState !== READY_STATE_OPEN ||
+    !wbot.user
+  ) {
     throw new AppError("ERR_WAPP_SESSION_NOT_READY");
   }
 
@@ -17,3 +20,4 @@ const EnsureWbotSession = (whatsapp: Whatsapp) => {
 };
 
 export default EnsureWbotSession;
+


### PR DESCRIPTION
## Summary
- adjust `EnsureWbotSession` to take a WASocket
- check websocket ready state with a cast to `any`

## Testing
- `npm run build`
- `npm test` *(fails: Loaded configuration file "dist/config/database.js")*


------
https://chatgpt.com/codex/tasks/task_e_686c1717e5048327b3a048be930843f1