### PR TITLE
Fix numeric fields validation

### DIFF
--- a/backend/src/services/WhatsappService/CreateWhatsAppService.ts
+++ b/backend/src/services/WhatsappService/CreateWhatsAppService.ts
@@ -192,6 +192,15 @@ const CreateWhatsAppService = async ({
     }
   }
 
+  const parsedTimeSendQueue =
+    typeof timeSendQueue === "string"
+      ? Number.parseInt(timeSendQueue, 10)
+      : Number(timeSendQueue);
+  const parsedSendIdQueue =
+    typeof sendIdQueue === "string"
+      ? Number.parseInt(sendIdQueue, 10)
+      : Number(sendIdQueue);
+
   const whatsapp = await Whatsapp.create(
     {
       name,
@@ -213,8 +222,12 @@ const CreateWhatsAppService = async ({
       timeUseBotQueues,
       expiresTicket,
       allowGroup,
-      timeSendQueue,
-      sendIdQueue,
+      timeSendQueue: Number.isNaN(parsedTimeSendQueue)
+        ? 0
+        : parsedTimeSendQueue,
+      sendIdQueue: Number.isNaN(parsedSendIdQueue)
+        ? null
+        : parsedSendIdQueue,
       timeInactiveMessage,
       inactiveMessage,
       maxUseBotQueuesNPS,

--- a/backend/src/services/WhatsappService/UpdateWhatsAppService.ts
+++ b/backend/src/services/WhatsappService/UpdateWhatsAppService.ts
@@ -120,6 +120,16 @@ const UpdateWhatsAppService = async ({
     throw new AppError("ERR_WAPP_GREETING_REQUIRED");
   }
 
+  const parsedTimeSendQueue =
+    typeof timeSendQueue === "string"
+      ? Number.parseInt(timeSendQueue, 10)
+      : Number(timeSendQueue);
+
+  const parsedSendIdQueue =
+    typeof sendIdQueue === "string"
+      ? Number.parseInt(sendIdQueue, 10)
+      : Number(sendIdQueue);
+
   let oldDefaultWhatsapp: Whatsapp | null = null;
 
   if (isDefault) {
@@ -152,8 +162,12 @@ const UpdateWhatsAppService = async ({
     timeUseBotQueues: timeUseBotQueues || 0,
     expiresTicket: expiresTicket || 0,
     allowGroup,
-    timeSendQueue,
-    sendIdQueue,
+    timeSendQueue: Number.isNaN(parsedTimeSendQueue)
+      ? 0
+      : parsedTimeSendQueue,
+    sendIdQueue: Number.isNaN(parsedSendIdQueue)
+      ? null
+      : parsedSendIdQueue,
     timeInactiveMessage,
     inactiveMessage,
     ratingMessage,


### PR DESCRIPTION
## Summary
- parse `timeSendQueue` and `sendIdQueue` before persisting WhatsApp records
- prevent invalid integer values on update

## Testing
- `npm test --prefix backend` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c1b44ef6883278f6abf70e3474f92