### PR TITLE
Fix daily report time comparison

### DIFF
--- a/backend/src/queues.ts
+++ b/backend/src/queues.ts
@@ -1923,7 +1923,14 @@ async function handleDailyReport() {
         const currentHour = moment().tz("America/Sao_Paulo").format("HH");
         const today = moment().tz("America/Sao_Paulo").format("YYYY-MM-DD");
 
-        if (currentHour !== timeSetting.value || lastSetting.value === today) {
+        const currentHourInt = parseInt(currentHour, 10);
+        const timeSettingInt = parseInt(timeSetting.value, 10);
+
+        if (
+          isNaN(timeSettingInt) ||
+          currentHourInt !== timeSettingInt ||
+          lastSetting.value === today
+        ) {
           continue;
         }
 


### PR DESCRIPTION
## Summary
- handle numeric formats for daily report scheduling

## Testing
- `npm test --prefix backend` *(fails: sequelize not found)*
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9fd2ad508327af40bbb975341f1d