### PR TITLE
Improve CEP consult concurrency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -86,7 +86,8 @@
     "winston": "^3.13.0",
     "xlsx": "^0.18.3",
     "yup": "^0.32.11",
-    "ioredis": "^4.28.5"
+    "ioredis": "^4.28.5",
+    "p-limit": "^6.2.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",


### PR DESCRIPTION
## Summary
- limit concurrent CPF lookups when consulting leads by CEP
- add `p-limit` dependency

## Testing
- `npm test` *(fails: Cannot find "dist/config/database.js")*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4fc09d3483278b0c1da84bb002c6