### PR TITLE
Fix lead phone number display

### DIFF
--- a/frontend/src/helpers/normalizeLeadItem.js
+++ b/frontend/src/helpers/normalizeLeadItem.js
@@ -68,5 +68,28 @@ export default function normalizeLeadItem(item) {
     }
   }
 
+  // Normalize phones to always be an array of objects
+  if (Array.isArray(lead.telefones)) {
+    lead.telefones = lead.telefones.map(t => ({
+      numero: t.numero || t.telefone || t.celular || "",
+      tipo: t.tipo || t.operadora || "",
+      whatsapp: t.whatsapp || false
+    }));
+  } else if (lead.telefones && typeof lead.telefones === "object") {
+    lead.telefones = Object.values(lead.telefones).map(t => ({
+      numero: t.numero || t.telefone || t.celular || "",
+      tipo: t.tipo || t.operadora || "",
+      whatsapp: t.whatsapp || false
+    }));
+  } else if (Array.isArray(lead.celulares)) {
+    lead.telefones = lead.celulares.map(c => ({ numero: c, tipo: "Celular" }));
+  } else if (lead.telefone) {
+    lead.telefones = [{ numero: lead.telefone, tipo: "Fixo" }];
+  } else if (lead.celular) {
+    lead.telefones = [{ numero: lead.celular, tipo: "Celular" }];
+  } else {
+    lead.telefones = Array.isArray(lead.telefones) ? lead.telefones : [];
+  }
+
   return lead;
 }


### PR DESCRIPTION
## Summary
- normalize phone data when transforming leads

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7ae441108327a051f26b571fab3b