### PR TITLE
Add env options to limit lead extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ as variáveis `API_TOKEN_CEP` e `API_TOKEN_CPF`. O frontend possui as variáveis
 `REACT_APP_API_TOKEN_CEP` e `REACT_APP_API_TOKEN_CPF`, utilizadas apenas para
 mensagens de aviso ao usuário.
 
+Caso a extração de leads gere muitas requisições, é possível controlar a
+quantidade de dados processados definindo `LEADS_PAGE_SIZE` (número de leads por
+página) e `LEADS_CONCURRENCY` (quantas consultas de CPF ocorrem em paralelo) no
+`.env` do backend.
+
 Ao configurar relatórios diários, defina o `dailyReportNumber` com um número de
 WhatsApp válido (contato ou grupo). O sistema valida esse contato antes do
 envio e registra falhas caso o número esteja incorreto.

--- a/backend/.env.exemple
+++ b/backend/.env.exemple
@@ -80,3 +80,9 @@ ADMIN_PHONE=
 # Tokens da Work API para consultas de CEP e CPF
 API_TOKEN_CEP=
 API_TOKEN_CPF=
+
+# Limites para extração de leads
+# Tamanho da página de resultados (padrão 100)
+LEADS_PAGE_SIZE=100
+# Número máximo de consultas de CPF em paralelo (padrão 5)
+LEADS_CONCURRENCY=5

--- a/backend/src/services/LeadsService/ConsultCepService.ts
+++ b/backend/src/services/LeadsService/ConsultCepService.ts
@@ -12,8 +12,14 @@ interface Request {
   page: number;
 }
 
-const PAGE_SIZE = 100;
-const CONCURRENCY = 5;
+const PAGE_SIZE = Math.max(
+  1,
+  parseInt(process.env.LEADS_PAGE_SIZE || "100", 10)
+);
+const CONCURRENCY = Math.max(
+  1,
+  parseInt(process.env.LEADS_CONCURRENCY || "5", 10)
+);
 const limit = pLimit(CONCURRENCY);
 
 const ConsultCepService = async ({ cep, companyId, userId, page }: Request) => {


### PR DESCRIPTION
## Summary
- make page size and concurrency for lead extraction configurable
- document the new environment variables in backend `.env` and README

## Testing
- `npm test` *(fails: Cannot find "dist/config/database.js")*
- `npm test -- -w 1` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686df6672fe483278cbfa922c0b5de22