### PR TITLE
Limit leads page size to 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ mensagens de aviso ao usuário.
 
 Caso a extração de leads gere muitas requisições, é possível controlar a
 quantidade de dados processados definindo `LEADS_PAGE_SIZE` (número de leads por
-página) e `LEADS_CONCURRENCY` (quantas consultas de CPF ocorrem em paralelo) no
-`.env` do backend.
+página, padrão 25) e `LEADS_CONCURRENCY` (quantas consultas de CPF ocorrem em
+paralelo) no `.env` do backend.
 
 Para evitar erros de CORS, configure `FRONTEND_URL` no backend com a URL
 do site que acessará a API, por exemplo `https://loopchat.com.br`. Se

--- a/backend/.env.exemple
+++ b/backend/.env.exemple
@@ -83,7 +83,7 @@ API_TOKEN_CEP=
 API_TOKEN_CPF=
 
 # Limites para extração de leads
-# Tamanho da página de resultados (padrão 100)
-LEADS_PAGE_SIZE=100
+# Tamanho da página de resultados (padrão 25)
+LEADS_PAGE_SIZE=25
 # Número máximo de consultas de CPF em paralelo (padrão 5)
 LEADS_CONCURRENCY=5

--- a/backend/src/services/LeadsService/ConsultCepService.ts
+++ b/backend/src/services/LeadsService/ConsultCepService.ts
@@ -14,7 +14,7 @@ interface Request {
 
 const PAGE_SIZE = Math.max(
   1,
-  parseInt(process.env.LEADS_PAGE_SIZE || "100", 10)
+  parseInt(process.env.LEADS_PAGE_SIZE || "25", 10)
 );
 const CONCURRENCY = Math.max(
   1,

--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -611,7 +611,7 @@ const Leads = () => {
                 onClick={handleLoadMore}
                 disabled={loadingMore}
               >
-                {loadingMore ? <CircularProgress size={20} /> : "+100"}
+                {loadingMore ? <CircularProgress size={20} /> : "+25"}
               </Button>
             )}
           </div>
@@ -627,5 +627,4 @@ const Leads = () => {
     </MainContainer>
   );
 };
-
 export default Leads;

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -343,7 +343,7 @@ const messages = {
                                         score: "Score",
                                 },
                                 creditsAvailable: "Available credits",
-                                creditInfo: "Each batch of 100 leads costs 1 credit",
+                                creditInfo: "Each batch of 25 leads costs 1 credit",
                                 cpfCreditInfo: "Each CPF lookup costs 3 credits",
                                 addCredits: "Add credits",
                                 historyCleared: "History cleared successfully",

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -1464,7 +1464,7 @@ const messages = {
       leads: {
         title: "Leads",
         creditsAvailable: "Créditos disponibles",
-        creditInfo: "Cada grupo de 100 leads consume 1 crédito",
+        creditInfo: "Cada grupo de 25 leads consume 1 crédito",
         cpfCreditInfo: "Cada consulta de CPF cuesta 3 créditos",
         addCredits: "Acreditar créditos",
         noCredits: "No tienes créditos suficientes",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -1537,7 +1537,7 @@ const messages = {
           score: "Score",
         },
         creditsAvailable: "Créditos disponíveis",
-        creditInfo: "Cada consulta de 100 leads consome 1 crédito",
+        creditInfo: "Cada consulta de 25 leads consome 1 crédito",
         cpfCreditInfo: "Cada consulta de CPF custa 3 créditos",
         addCredits: "Creditar créditos",
         historyCleared: "Histórico apagado com sucesso",


### PR DESCRIPTION
## Summary
- set leads page size default to 25
- update docs and env example with new default
- update translation strings
- tweak leads page button text

## Testing
- `npm test` in `backend` *(fails: sequelize not found)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed9b0bc90832780864e651f0d9159