### PR TITLE
Improve CORS flexibility

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -45,11 +45,12 @@ app.set("queues", {
   sendScheduledMessages
 });
 
-// Permitir múltiplos domínios separados por vírgula em FRONTEND_URL
+// Permitir múltiplos domínios separados por vírgula em FRONTEND_URL.
+// Caso nenhuma origem seja definida, todas serão permitidas.
 const allowedOrigins = process.env.FRONTEND_URL
   ? process.env.FRONTEND_URL.split(',').map(origin => origin.trim())
   : [];
-console.log('Allowed origins:', allowedOrigins);
+console.log('Allowed origins:', allowedOrigins.length ? allowedOrigins : 'all');
 
 // Configuração do BullBoard
 if (String(process.env.BULL_BOARD).toLocaleLowerCase() === 'true' && process.env.REDIS_URI_ACK !== '') {
@@ -82,7 +83,12 @@ app.use(bodyParser.urlencoded({ limit: '5mb', extended: true }));
 app.use(
   cors({
     credentials: true,
-    origin: allowedOrigins
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.length === 0 || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error('Not allowed by CORS'));
+    }
   })
 );
 app.use(cookieParser());

--- a/backend/src/libs/socket.ts
+++ b/backend/src/libs/socket.ts
@@ -11,9 +11,21 @@ export const initIO = (httpServer: Server): SocketIO => {
   const origins = process.env.FRONTEND_URL
     ? process.env.FRONTEND_URL.split(',').map(o => o.trim())
     : [];
+
+  console.log(
+    'Socket allowed origins:',
+    origins.length ? origins : 'all'
+  );
+
   io = new SocketIO(httpServer, {
     cors: {
-      origin: origins
+      credentials: true,
+      origin: (origin, callback) => {
+        if (!origin || origins.length === 0 || origins.includes(origin)) {
+          return callback(null, true);
+        }
+        return callback(new Error('Not allowed by CORS'));
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- improve allowed origins logic for CORS
- allow any origin if `FRONTEND_URL` is not set
- dynamically validate origin to return proper CORS headers

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: sequelize: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee6d14cdc832789e5e01095309bac