### PR TITLE
Optimize Consult CEP service

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,13 @@ mensagens de aviso ao usuário.
 Caso a extração de leads gere muitas requisições, é possível controlar a
 quantidade de dados processados definindo `LEADS_PAGE_SIZE` (número de leads por
 página, padrão 25) e `LEADS_CONCURRENCY` (quantas consultas de CPF ocorrem em
-paralelo) no `.env` do backend.
-Se as consultas demorarem muito, ajuste também `REQUEST_TIMEOUT_MS`, definido em
-milissegundos (padrão 90000).
+paralelo) no `.env` do backend. Se as consultas demorarem muito, ajuste também
+`REQUEST_TIMEOUT_MS`, definido em milissegundos (padrão 60000).
+
+Ao chamar `GET /consult/cep/:cep` é possível controlar se os telefones devem ser
+buscados enviando o parâmetro de consulta `phones=true`. Para as páginas 1 e 2
+os telefones são retornados por padrão; nas demais páginas utilize esse
+parâmetro quando realmente quiser carregá-los.
 
 Para evitar erros de CORS, configure `FRONTEND_URL` no backend com a URL
 do site que acessará a API, por exemplo `https://loopchat.com.br`. Se

--- a/backend/.env.exemple
+++ b/backend/.env.exemple
@@ -87,5 +87,5 @@ API_TOKEN_CPF=
 LEADS_PAGE_SIZE=25
 # Número máximo de consultas de CPF em paralelo (padrão 5)
 LEADS_CONCURRENCY=5
-# Tempo máximo (em ms) para as requisições à Work API (padrão 90000)
-REQUEST_TIMEOUT_MS=90000
+# Tempo máximo (em ms) para as requisições à Work API (padrão 60000)
+REQUEST_TIMEOUT_MS=60000

--- a/backend/src/controllers/ConsultController.ts
+++ b/backend/src/controllers/ConsultController.ts
@@ -7,12 +7,14 @@ export const consultCep = async (req: Request, res: Response): Promise<Response>
   const { cep } = req.params;
   const { companyId, id } = req.user;
   const page = parseInt(req.query.page as string) || 1;
+  const fetchPhones = req.query.phones === "true";
 
   const result = await ConsultCepService({
     cep,
     companyId,
     userId: parseInt(id),
-    page
+    page,
+    fetchPhones
   });
 
   return res.status(200).json(result);

--- a/backend/src/services/LeadsService/ConsultCpfService.ts
+++ b/backend/src/services/LeadsService/ConsultCpfService.ts
@@ -17,8 +17,8 @@ const ConsultCpfService = async ({ cpf, companyId, free = false }: Request) => {
 
   const REQUEST_TIMEOUT = Math.max(
     1000,
-    // Tempo limite para a consulta de CPF (padrão 90 segundos)
-    parseInt(process.env.REQUEST_TIMEOUT_MS || "90000", 10)
+    // Tempo limite para a consulta de CPF (padrão 60 segundos)
+    parseInt(process.env.REQUEST_TIMEOUT_MS || "60000", 10)
   );
 
   const balance = await ConsumeCreditsService(companyId, free ? 0 : 3);

--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -311,7 +311,9 @@ const Leads = () => {
     const next = pageApi + 1;
     setLoadingMore(true);
     try {
-      const { data } = await api.get(`/consult/cep/${cep}?page=${next}`);
+      const { data } = await api.get(
+        `/consult/cep/${cep}?page=${next}&phones=true`
+      );
       const leads = (data.leads || []).map(normalizeLeadItem);
       setResults((prev) => [...prev, ...leads]);
       setHasMore(data.hasMore);


### PR DESCRIPTION
## Summary
- add optional `phones` query param in ConsultController
- default phone retrieval to first two pages
- log phone lookup duration and skip for later pages unless requested
- reduce default API timeout to 60s
- pass `phones=true` when loading more leads in frontend
- document optional `phones` parameter and timeout changes

## Testing
- `npm test` (fails: sequelize not found)
- `npm test --silent` in frontend (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_686ef612027883278b4d5dc41936fedb