### PR TITLE
Always fetch phone numbers from CEP results

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,8 @@ página, padrão 25) e `LEADS_CONCURRENCY` (quantas consultas de CPF ocorrem em
 paralelo) no `.env` do backend. Se as consultas demorarem muito, ajuste também
 `REQUEST_TIMEOUT_MS`, definido em milissegundos (padrão 60000).
 
-Ao chamar `GET /consult/cep/:cep` é possível controlar se os telefones devem ser
-buscados enviando o parâmetro de consulta `phones=true`. Para as páginas 1 e 2
-os telefones são retornados por padrão; nas demais páginas utilize esse
-parâmetro quando realmente quiser carregá-los.
+Ao chamar `GET /consult/cep/:cep` os telefones são buscados por padrão em todos
+os resultados. Caso não queira carregá-los, envie `phones=false` na consulta.
 
 Para evitar erros de CORS, configure `FRONTEND_URL` no backend com a URL
 do site que acessará a API, por exemplo `https://loopchat.com.br`. Se

--- a/backend/src/services/LeadsService/ConsultCepService.ts
+++ b/backend/src/services/LeadsService/ConsultCepService.ts
@@ -91,7 +91,7 @@ const ConsultCepService = async ({
   const slice = freshLeads.slice(start, start + PAGE_SIZE);
   console.log(`📦 Página ${page}: ${slice.length} leads para retornar.`);
   const shouldFetchPhones =
-    typeof fetchPhones === "boolean" ? fetchPhones : page <= 2;
+    typeof fetchPhones === "boolean" ? fetchPhones : true;
   console.log(`📞 Buscar telefones nesta página: ${shouldFetchPhones}`);
 
   if (slice.length > 0) {

--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -168,7 +168,7 @@ const Leads = () => {
     setLoading(true);
     setTokenError(false);
     try {
-      const { data } = await api.get(`/consult/cep/${cleanCep}?page=1`);
+      const { data } = await api.get(`/consult/cep/${cleanCep}?page=1&phones=true`);
       const leads = (data.leads || []).map(normalizeLeadItem);
       setResults(leads);
       if (leads.length > 0) {


### PR DESCRIPTION
## Summary
- fetch phone numbers for every CEP page by default
- note new behaviour in README
- send `phones=true` when requesting the first page in the leads screen

## Testing
- `npm run build` (backend)
- `npm run build` (frontend) *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871148a10c4832784ca0cdbab183c4d