### PR TITLE
Move daily report fields to ReportLogs tab

### DIFF
--- a/frontend/src/components/ReportLogs/index.js
+++ b/frontend/src/components/ReportLogs/index.js
@@ -1,9 +1,28 @@
 import React, { useEffect, useState } from "react";
-import { Paper, Table, TableHead, TableRow, TableCell, TableBody } from "@material-ui/core";
+import {
+  Paper,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Grid,
+  TextField,
+  FormControl,
+  FormHelperText
+} from "@material-ui/core";
 import { listReportLogs } from "../../services/reportLogsApi";
+import useSettings from "../../hooks/useSettings";
+import { i18n } from "../../translate/i18n";
 
 const ReportLogs = () => {
   const [logs, setLogs] = useState([]);
+  const [dailyReportNumber, setDailyReportNumber] = useState("");
+  const [loadingDailyReportNumber, setLoadingDailyReportNumber] = useState(false);
+  const [dailyReportTime, setDailyReportTime] = useState("19");
+  const [loadingDailyReportTime, setLoadingDailyReportTime] = useState(false);
+
+  const { getAll, update } = useSettings();
 
   useEffect(() => {
     const fetch = async () => {
@@ -17,8 +36,78 @@ const ReportLogs = () => {
     fetch();
   }, []);
 
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const data = await getAll();
+        const dailyNumber = data.find((s) => s.key === "dailyReportNumber");
+        if (dailyNumber) setDailyReportNumber(dailyNumber.value);
+        const dailyTime = data.find((s) => s.key === "dailyReportTime");
+        if (dailyTime) setDailyReportTime(dailyTime.value);
+      } catch (err) {
+        // ignore
+      }
+    };
+    fetchSettings();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function handleDailyReportNumber(value) {
+    setDailyReportNumber(value);
+    setLoadingDailyReportNumber(true);
+    await update({ key: "dailyReportNumber", value });
+    setLoadingDailyReportNumber(false);
+  }
+
+  async function handleDailyReportTime(value) {
+    setDailyReportTime(value);
+    setLoadingDailyReportTime(true);
+    await update({ key: "dailyReportTime", value });
+    setLoadingDailyReportTime(false);
+  }
+
   return (
     <Paper style={{ overflowX: "auto" }}>
+      <Grid spacing={3} container style={{ padding: 10 }}>
+        <Grid xs={12} sm={6} item>
+          <FormControl fullWidth>
+            <TextField
+              id="dailyReportNumber"
+              name="dailyReportNumber"
+              margin="dense"
+              label={i18n.t("settings.settings.options.dailyReportNumber")}
+              variant="outlined"
+              value={dailyReportNumber}
+              onChange={async (e) => {
+                handleDailyReportNumber(e.target.value);
+              }}
+            />
+            <FormHelperText>
+              {loadingDailyReportNumber &&
+                i18n.t("settings.settings.options.updating")}
+            </FormHelperText>
+          </FormControl>
+        </Grid>
+        <Grid xs={12} sm={6} item>
+          <FormControl fullWidth>
+            <TextField
+              id="dailyReportTime"
+              name="dailyReportTime"
+              margin="dense"
+              label={i18n.t("settings.settings.options.dailyReportTime")}
+              variant="outlined"
+              value={dailyReportTime}
+              onChange={async (e) => {
+                handleDailyReportTime(e.target.value);
+              }}
+            />
+            <FormHelperText>
+              {loadingDailyReportTime &&
+                i18n.t("settings.settings.options.updating")}
+            </FormHelperText>
+          </FormControl>
+        </Grid>
+      </Grid>
       <Table size="small">
         <TableHead>
           <TableRow>

--- a/frontend/src/components/Settings/Options.js
+++ b/frontend/src/components/Settings/Options.js
@@ -181,11 +181,6 @@ export default function Options(props) {
   const [showNotificationPending, setShowNotificationPending] = useState(false);
   const [loadingShowNotificationPending, setLoadingShowNotificationPending] = useState(false);
 
-  const [dailyReportNumber, setDailyReportNumber] = useState("");
-  const [loadingDailyReportNumber, setLoadingDailyReportNumber] = useState(false);
-
-  const [dailyReportTime, setDailyReportTime] = useState("19");
-  const [loadingDailyReportTime, setLoadingDailyReportTime] = useState(false);
 
   const { update: updateUserCreation, getAll } = useSettings();
 
@@ -258,15 +253,6 @@ export default function Options(props) {
         setopenaitokenType(openaitokenType.value);
       }
 
-      const dailyNumber = oldSettings.find((s) => s.key === 'dailyReportNumber');
-      if (dailyNumber) {
-        setDailyReportNumber(dailyNumber.value);
-      }
-
-      const dailyTime = oldSettings.find((s) => s.key === 'dailyReportTime');
-      if (dailyTime) {
-        setDailyReportTime(dailyTime.value);
-      }
     }
   }, [oldSettings])
 
@@ -299,8 +285,6 @@ export default function Options(props) {
       if (key === "AcceptCallWhatsappMessage") setAcceptCallWhatsappMessage(value);
       if (key === "sendQueuePositionMessage") setSendQueuePositionMessage(value);
       if (key === "showNotificationPending") setShowNotificationPending(value);
-      if (key === "dailyReportNumber") setDailyReportNumber(value);
-      if (key === "dailyReportTime") setDailyReportTime(value);
 
     }
   }, [settings]);
@@ -496,25 +480,6 @@ export default function Options(props) {
     setLoadingShowNotificationPending(false);
   }
 
-  async function handleDailyReportNumber(value) {
-    setDailyReportNumber(value);
-    setLoadingDailyReportNumber(true);
-    await updateUserCreation({
-      key: "dailyReportNumber",
-      value,
-    });
-    setLoadingDailyReportNumber(false);
-  }
-
-  async function handleDailyReportTime(value) {
-    setDailyReportTime(value);
-    setLoadingDailyReportTime(true);
-    await updateUserCreation({
-      key: "dailyReportTime",
-      value,
-    });
-    setLoadingDailyReportTime(false);
-  }
 
   async function handleLGPDLink(value) {
     setLGPDLink(value);
@@ -1518,46 +1483,7 @@ export default function Options(props) {
           </Grid>
         </Grid>
 
-        <Grid spacing={3} container style={{ marginBottom: 10 }}>
-          <Grid xs={12} sm={6} md={6} item>
-            <FormControl className={classes.selectContainer}>
-              <TextField
-                id="dailyReportNumber"
-                name="dailyReportNumber"
-                margin="dense"
-                label={i18n.t("settings.settings.options.dailyReportNumber")}
-                variant="outlined"
-                value={dailyReportNumber}
-                onChange={async (e) => {
-                  handleDailyReportNumber(e.target.value);
-                }}
-              ></TextField>
-              <FormHelperText>
-                {loadingDailyReportNumber && i18n.t("settings.settings.options.updating")}
-              </FormHelperText>
-            </FormControl>
-          </Grid>
-          {isSuper() ?
-          <Grid xs={12} sm={6} md={6} item>
-            <FormControl className={classes.selectContainer}>
-              <TextField
-                id="dailyReportTime"
-                name="dailyReportTime"
-                margin="dense"
-                label={i18n.t("settings.settings.options.dailyReportTime")}
-                variant="outlined"
-                value={dailyReportTime}
-                onChange={async (e) => {
-                  handleDailyReportTime(e.target.value);
-                }}
-              ></TextField>
-              <FormHelperText>
-                {loadingDailyReportTime && i18n.t("settings.settings.options.updating")}
-              </FormHelperText>
-            </FormControl>
-          </Grid>
-          : null}
-        </Grid>
+
 
       <Grid spacing={1} container>
         <Grid xs={12} sm={6} md={6} item>


### PR DESCRIPTION
## Summary
- move daily report fields from `Options` to `ReportLogs`
- adjust `ReportLogs` to fetch/update settings and render new fields

## Testing
- `npm test` *(fails: sequelize/react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871171c9bf48327944aa74d6bc7f2d3