### PR TITLE
Implement tags page permission

### DIFF
--- a/backend/src/database/migrations/20250707170201-add-allowTags-to-users.ts
+++ b/backend/src/database/migrations/20250707170201-add-allowTags-to-users.ts
@@ -1,0 +1,15 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return queryInterface.addColumn("Users", "allowTags", {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "disabled"
+    });
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return queryInterface.removeColumn("Users", "allowTags");
+  }
+};

--- a/backend/src/helpers/SerializeUser.ts
+++ b/backend/src/helpers/SerializeUser.ts
@@ -28,6 +28,7 @@ interface SerializedUser {
   allowGroup: boolean;
   allowRealTime: string;
   allowConnections: string;
+  allowTags: string;
 }
 
 export const SerializeUser = async (user: User): Promise<SerializedUser> => {
@@ -62,6 +63,7 @@ export const SerializeUser = async (user: User): Promise<SerializedUser> => {
     token: generateToken(user.id),
     allowGroup: user.allowGroup,
     allowRealTime: user.allowRealTime,
-    allowConnections: user.allowConnections
+    allowConnections: user.allowConnections,
+    allowTags: user.allowTags
   };
 };

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -174,6 +174,10 @@ class User extends Model<User> {
   @Column
   allowConnections: string;
 
+  @Default("disabled")
+  @Column
+  allowTags: string;
+
   @BeforeDestroy
   static async updateChatbotsUsersReferences(user: User) {
     // Atualizar os registros na tabela Chatbots onde optQueueId é igual ao ID da fila que será excluída

--- a/backend/src/services/UserServices/CreateUserService.ts
+++ b/backend/src/services/UserServices/CreateUserService.ts
@@ -27,6 +27,7 @@ interface Request {
   defaultTicketsManagerWidth?: number;
   allowRealTime?: string;
   allowConnections?: string;
+  allowTags?: string;
 }
 
 interface Response {
@@ -56,7 +57,8 @@ const CreateUserService = async ({
   showDashboard,
   defaultTicketsManagerWidth = 550,
   allowRealTime,
-  allowConnections
+  allowConnections,
+  allowTags
 }: Request): Promise<Response> => {
   if (companyId !== undefined) {
     const company = await Company.findOne({
@@ -127,7 +129,8 @@ const CreateUserService = async ({
       showDashboard,
       defaultTicketsManagerWidth,
       allowRealTime,
-      allowConnections
+      allowConnections,
+      allowTags
     },
     { include: ["queues", "company"] }
   );

--- a/backend/src/services/UserServices/ShowUserService.ts
+++ b/backend/src/services/UserServices/ShowUserService.ts
@@ -35,7 +35,8 @@ const ShowUserService = async (id: string | number, companyId: string | number):
         "allUserChat",
         "allHistoric",
         "allowRealTime",
-        "allowConnections"
+        "allowConnections",
+        "allowTags"
       ],
       include: [
         { model: Queue, as: "queues", attributes: ["id", "name", "color"] },

--- a/backend/src/services/UserServices/UpdateUserService.ts
+++ b/backend/src/services/UserServices/UpdateUserService.ts
@@ -27,6 +27,7 @@ interface UserData {
   defaultTicketsManagerWidth?: number;
   allowRealTime?: string;
   allowConnections?: string;
+  allowTags?: string;
   profileImage?: string;
 }
 
@@ -89,7 +90,8 @@ const UpdateUserService = async ({
     allowConnections,
     defaultTicketsManagerWidth = 550,
     allowRealTime,
-    profileImage
+    profileImage,
+    allowTags
   } = userData;
 
   try {
@@ -118,7 +120,8 @@ const UpdateUserService = async ({
     defaultTicketsManagerWidth,
     allowRealTime,
     profileImage,
-    allowConnections
+    allowConnections,
+    allowTags
   });
 
   await user.$set("queues", queueIds);
@@ -155,6 +158,7 @@ const UpdateUserService = async ({
     defaultTicketsManagerWidth: user.defaultTicketsManagerWidth,
     allowRealTime: user.allowRealTime,
     allowConnections: user.allowConnections,
+    allowTags: user.allowTags,
     profileImage: user.profileImage
   };
 

--- a/frontend/src/components/UserModal/index.js
+++ b/frontend/src/components/UserModal/index.js
@@ -135,10 +135,11 @@ const UserModal = ({ open, onClose, userId }) => {
 		allHistoric: "disabled",
 		allUserChat: "disabled",
 		userClosePendingTicket: "enabled",
-		showDashboard: "disabled",
-		allowRealTime: "disabled",
-		allowConnections: "disabled",
-	};
+                showDashboard: "disabled",
+                allowRealTime: "disabled",
+                allowConnections: "disabled",
+                allowTags: "disabled",
+        };
 
 	const { user: loggedInUser } = useContext(AuthContext);
 
@@ -760,24 +761,46 @@ const UserModal = ({ open, onClose, userId }) => {
 																		{i18n.t("userModal.form.allowRealTime")}
 																	</InputLabel>
 
-																	<Field
-																		as={Select}
-																		label={i18n.t("userModal.form.allowRealTime")}
-																		name="allowRealTime"
-																		type="allowRealTime"
-																		required
-																	>
-																		<MenuItem value="disabled">{i18n.t("userModal.form.allHistoricDisabled")}</MenuItem>
-																		<MenuItem value="enabled">{i18n.t("userModal.form.allHistoricEnabled")}</MenuItem>
-																	</Field>
-																</>
-															</FormControl>
-														</Grid>
-													</Grid>
-												</>
-											}
-										/>
-									</TabPanel>
+            <Field
+              as={Select}
+              label={i18n.t("userModal.form.allowRealTime")}
+              name="allowRealTime"
+              type="allowRealTime"
+              required
+            >
+              <MenuItem value="disabled">{i18n.t("userModal.form.allHistoricDisabled")}</MenuItem>
+              <MenuItem value="enabled">{i18n.t("userModal.form.allHistoricEnabled")}</MenuItem>
+            </Field>
+            </>
+            </FormControl>
+          </Grid>
+          <Grid item xs={12} md={6} xl={6}>
+            <FormControl
+              variant="outlined"
+              className={classes.maxWidth}
+              margin="dense"
+              fullWidth
+            >
+              <InputLabel >
+                {i18n.t("userModal.form.allowTags")}
+              </InputLabel>
+              <Field
+                as={Select}
+                label={i18n.t("userModal.form.allowTags")}
+                name="allowTags"
+                type="allowTags"
+                required
+              >
+                <MenuItem value="disabled">{i18n.t("userModal.form.allHistoricDisabled")}</MenuItem>
+                <MenuItem value="enabled">{i18n.t("userModal.form.allHistoricEnabled")}</MenuItem>
+              </Field>
+            </FormControl>
+          </Grid>
+        </Grid>
+        </>
+        }
+        />
+      </TabPanel>
 								</DialogContent>
 							</Paper>
 							<DialogActions>

--- a/frontend/src/layout/MainListItems.js
+++ b/frontend/src/layout/MainListItems.js
@@ -532,12 +532,14 @@ const MainListItems = ({ collapsed, drawerClose }) => {
         </>
       )}
     {planExpired && (
-      <ListItemLink
-        to="/tags"
-        primary={i18n.t("mainDrawer.listItems.tags")}
-        icon={<LocalOfferIcon />}
-        tooltip={collapsed}
-      />
+      user.profile === "user" && user.allowTags === "disabled" ? null : (
+        <ListItemLink
+          to="/tags"
+          primary={i18n.t("mainDrawer.listItems.tags")}
+          icon={<LocalOfferIcon />}
+          tooltip={collapsed}
+        />
+      )
     )}
 
       {showInternalChat && planExpired && (

--- a/frontend/src/pages/Tags/index.js
+++ b/frontend/src/pages/Tags/index.js
@@ -38,6 +38,7 @@ import { Chip, Tooltip } from "@material-ui/core";
 import { AuthContext } from "../../context/Auth/AuthContext";
 import { MoreHoriz } from "@material-ui/icons";
 import ContactTagListModal from "../../components/ContactTagListModal";
+import ForbiddenPage from "../../components/ForbiddenPage";
 
 const reducer = (state, action) => {
   switch (action.type) {
@@ -186,6 +187,8 @@ const Tags = () => {
   };
 
   return (
+    user.profile === "user" && user.allowTags === "disabled" ?
+      <ForbiddenPage /> :
     <MainContainer className={classes.mainContainer}>
       {contactModalOpen && (
         <ContactTagListModal

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -615,6 +615,7 @@ const messages = {
           showDashboard: "Ver Dashboard",
           allowRealTime: "Ver Painel de Atendimentos",
           allowConnections: "Permitir ações nas conexões",
+          allowTags: "Habilitar página Tags",
         },
         tabs: {
           general: "Geral",


### PR DESCRIPTION
## Summary
- add DB migration and model field for tags permission
- serialize new tag permission in user data
- support allowTags in user services
- show/hide tags page and menu by permission
- expose permission control in user modal
- update Portuguese translations

## Testing
- `npm test` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_687127b914408327bd2cf445b9d82e03