### PR TITLE
Adjust leads download options

### DIFF
--- a/frontend/src/pages/Leads/index.js
+++ b/frontend/src/pages/Leads/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useContext } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import api from "../../services/api";
 import { makeStyles } from "@material-ui/core/styles";
 import {
@@ -18,7 +18,6 @@ import {
 } from "@material-ui/core";
 import Pagination from "@material-ui/lab/Pagination";
 import ReactInputMask from "react-input-mask";
-import { CSVLink } from "react-csv";
 import html2pdf from "html2pdf.js";
 import * as XLSX from "xlsx";
 import SearchIcon from "@material-ui/icons/Search";
@@ -101,7 +100,6 @@ const Leads = () => {
   const [canConsultCpf, setCanConsultCpf] = useState(false);
   const { dateToClient } = useDate();
   const [downloadAnchorEl, setDownloadAnchorEl] = useState(null);
-  const csvLinkRef = useRef();
 
   useEffect(() => {
     async function fetchPermission() {
@@ -255,13 +253,6 @@ const Leads = () => {
     setDownloadAnchorEl(null);
   };
 
-  const handleDownloadCsv = () => {
-    if (csvLinkRef.current) {
-      csvLinkRef.current.link.click();
-    }
-    handleDownloadClose();
-  };
-
   const handleDownloadLoopchat = () => {
     const rows = [];
     results.forEach((lead) => {
@@ -283,16 +274,20 @@ const Leads = () => {
   };
 
   const handleDownloadPdf = () => {
-    const container = document.createElement('div');
-    container.style.padding = '16px';
+    const container = document.createElement("div");
+    container.style.padding = "16px";
     results.forEach((lead) => {
-      const card = document.createElement('div');
-      card.style.border = '1px solid #ccc';
-      card.style.marginBottom = '12px';
-      card.style.padding = '12px';
-      card.innerHTML = `<h3>${lead.dados_pessoais?.nome || ''}</h3>
-        <p><strong>CPF:</strong> ${lead.dados_pessoais?.cpf || ''}</p>
-        <p><strong>Renda:</strong> ${lead.dados_pessoais?.renda || ''}</p>`;
+      const card = document.createElement("div");
+      card.style.border = "1px solid #ccc";
+      card.style.marginBottom = "12px";
+      card.style.padding = "12px";
+      const phones = Array.isArray(lead.telefones)
+        ? lead.telefones.map((t) => t.numero).join(", ")
+        : "";
+      const birth = dateToClient(lead.dados_pessoais?.nasc);
+      card.innerHTML = `<h3>${lead.dados_pessoais?.nome || ""}</h3>
+        <p><strong>Telefones:</strong> ${phones}</p>
+        <p><strong>Data de Nascimento:</strong> ${birth}</p>`;
       container.appendChild(card);
     });
     html2pdf()
@@ -509,14 +504,8 @@ const Leads = () => {
           >
             <MenuItem onClick={handleDownloadPdf}>Baixar em PDF</MenuItem>
             <MenuItem onClick={handleDownloadLoopchat}>Baixar Loopchat</MenuItem>
-            <MenuItem onClick={handleDownloadCsv}>Baixar CSV Completo</MenuItem>
           </Menu>
-          <CSVLink
-            data={results}
-            filename={`leads-${cep}.csv`}
-            ref={csvLinkRef}
-            style={{ display: "none" }}
-          />
+          
           <Fade in>
             <Paper className={classes.tableWrapper} variant="outlined">
               <Table size="small">


### PR DESCRIPTION
## Summary
- strip CSV export from leads page
- show only name, phone and birth date in downloaded PDF

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm test` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712d5f06888327b146ca06e754b871