### PR TITLE
Fix Pix amount handling

### DIFF
--- a/backend/src/controllers/SubscriptionController.ts
+++ b/backend/src/controllers/SubscriptionController.ts
@@ -233,7 +233,7 @@ if(key_GERENCIANET_PIX_KEY){
       expiracao: 3600
     },
     valor: {
-      original: price.toLocaleString("pt-br", { minimumFractionDigits: 2 }).replace(",", ".")
+      original: Number(price).toFixed(2)
     },
     chave: key_GERENCIANET_PIX_KEY,
     solicitacaoPagador: `#Fatura:${invoiceId}`


### PR DESCRIPTION
## Summary
- fix `pixCreateImmediateCharge` payload to format amounts correctly

## Testing
- `npm test` (fails: `sequelize: not found`)
- `npm test` in frontend (fails: `react-scripts: not found`)


------
https://chatgpt.com/codex/tasks/task_e_68719db18b0c83278b2c0fb8a9c13acb