### PR TITLE
Handle startup errors in maturation service

### DIFF
--- a/backend/src/services/MaturationService/MaturationManager.ts
+++ b/backend/src/services/MaturationService/MaturationManager.ts
@@ -4,6 +4,7 @@ import ChipMaturation from "../../models/ChipMaturation";
 import ChipMaturationLog from "../../models/ChipMaturationLog";
 import { SendMessage } from "../../helpers/SendMessage";
 import { getIO } from "../../libs/socket";
+import logger from "../../utils/logger";
 
 export type MaturationStatus = "running" | "completed" | "canceled";
 
@@ -175,7 +176,11 @@ class MaturationManager {
 
     this.jobs.set(id, job);
 
-    await this.executeJob(id);
+    try {
+      await this.executeJob(id);
+    } catch (err) {
+      logger.error(`Failed to start maturation job ${id}: ${err}`);
+    }
 
     return job;
   }


### PR DESCRIPTION
## Summary
- log and swallow errors if starting a chip maturation job fails

## Testing
- `npm run build --prefix backend`
- `npm test --prefix backend` *(fails: Cannot find dist/config/database.js)*

------
https://chatgpt.com/codex/tasks/task_e_687318243e9c8327a96af9ebc1d7679c