### PR TITLE
Fix maturation job timeout code

### DIFF
--- a/backend/src/controllers/MaturationController.ts
+++ b/backend/src/controllers/MaturationController.ts
@@ -3,9 +3,8 @@ import * as MaturationService from "../services/MaturationService";
 import { MaturationJob } from "../services/MaturationService/MaturationManager";
 
 const formatJob = (job: MaturationJob) => {
-  const { timeout, ...rest } = job;
   return {
-    ...rest,
+    ...job,
     progress:
       (Date.now() - job.startAt.getTime()) /
       (job.endAt.getTime() - job.startAt.getTime()),

--- a/backend/src/services/MaturationService/JobRunner.ts
+++ b/backend/src/services/MaturationService/JobRunner.ts
@@ -19,9 +19,8 @@ class JobRunner {
   }
 
   public serialize() {
-    const { timeout, ...rest } = this.job;
     return {
-      ...rest,
+      ...this.job,
       progress:
         (Date.now() - this.job.startAt.getTime()) /
         (this.job.endAt.getTime() - this.job.startAt.getTime())
@@ -29,7 +28,7 @@ class JobRunner {
   }
 
   private scheduleNext(delayMinutes?: number) {
-    const interval = delayMinutes ?? this.job.intervalMinutes || this.job.intervalHours * 60;
+    const interval = delayMinutes ?? (this.job.intervalMinutes || this.job.intervalHours * 60);
     const delay = interval * 60 * 1000;
     this.timeout = setTimeout(() => this.execute(), delay);
   }


### PR DESCRIPTION
## Summary
- remove obsolete `timeout` handling
- fix interval computation in `JobRunner`

## Testing
- `npm run build`
- `npm test` *(fails: Sequelize CLI requires database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687324662d548327b2d37f857de1deff