### PR TITLE
Improve WhatsApp session connectivity check

### DIFF
--- a/backend/src/helpers/isWhatsappConnected.ts
+++ b/backend/src/helpers/isWhatsappConnected.ts
@@ -1,13 +1,27 @@
 import Whatsapp from "../models/Whatsapp";
 import GetWhatsappWbot from "./GetWhatsappWbot";
 import EnsureWbotSession from "./EnsureWbotSession";
+import { StartWhatsAppSession } from "../services/WbotServices/StartWhatsAppSession";
+import logger from "../utils/logger";
 
 const isWhatsappConnected = async (whatsapp: Whatsapp): Promise<boolean> => {
   try {
     EnsureWbotSession(await GetWhatsappWbot(whatsapp));
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    logger.warn(`[isWhatsappConnected] ensure failed for ${whatsapp.id}:`, err);
+    try {
+      // restarts the session using WhatsApp ID and company ID
+      await StartWhatsAppSession(whatsapp.id, whatsapp.companyId);
+      EnsureWbotSession(await GetWhatsappWbot(whatsapp));
+      return true;
+    } catch (restartErr) {
+      logger.error(
+        `[isWhatsappConnected] restart failed for ${whatsapp.id}:`,
+        restartErr
+      );
+      return false;
+    }
   }
 };
 


### PR DESCRIPTION
## Summary
- connect to WhatsApp by restarting the session when needed
- log session check and restart errors
- call StartWhatsAppSession using WhatsApp ID as requested

## Testing
- `npm test` *(fails: Cannot find "/workspace/teste/backend/dist/config/database.js". Have you run "sequelize init"?)*

------
https://chatgpt.com/codex/tasks/task_e_68740c6c1efc8327946340f97de3b3d7