### PR TITLE
Fix WhatsApp restart parameter

### DIFF
--- a/backend/src/helpers/isWhatsappConnected.ts
+++ b/backend/src/helpers/isWhatsappConnected.ts
@@ -12,7 +12,7 @@ const isWhatsappConnected = async (whatsapp: Whatsapp): Promise<boolean> => {
     logger.warn(`[isWhatsappConnected] ensure failed for ${whatsapp.id}:`, err);
     try {
       // restarts the session using WhatsApp ID and company ID
-      await StartWhatsAppSession(whatsapp.id, whatsapp.companyId);
+      await StartWhatsAppSession(whatsapp, whatsapp.companyId);
       EnsureWbotSession(await GetWhatsappWbot(whatsapp));
       return true;
     } catch (restartErr) {


### PR DESCRIPTION
## Summary
- fix incorrect parameter when restarting WhatsApp session

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68740f4aa4288327b0eb8884201d4fab