### PR TITLE
Improve pm2 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,21 @@ Para gerar uma versão pronta para produção:
 4. Certifique-se de que os arquivos `.env` contêm as configurações corretas no servidor.
 5. Inicie ambos os serviços usando `node` ou o gerenciador de processos de sua preferência.
 
+### Executando com PM2
+
+Se optar por utilizar o **pm2** para gerenciar o backend, certifique-se de que as
+variáveis de ambiente do arquivo `.env` sejam carregadas. Uma forma simples é
+adicionar `env_file: '.env'` no arquivo `backend/ecosystem.config.js` e executar
+
+```bash
+cd backend
+pm2 start ecosystem.config.js
+```
+
+Isso garante que o processo será iniciado no diretório correto e que as
+credenciais de serviços como Redis serão preservadas entre os reinícios,
+mantendo as sessões do WhatsApp ativas após um build.
+
 ## Executando os testes
 
 Os testes estão configurados no backend e no frontend. Basta rodar:

--- a/backend/ecosystem.config.js
+++ b/backend/ecosystem.config.js
@@ -3,6 +3,11 @@ module.exports = [{
   name: 'multipremium-back',
   exec_mode: 'fork',
   cron_restart: '05 00 * * *',
+  cwd: __dirname,
+  env_file: '.env',
+  env: {
+    NODE_ENV: 'production'
+  },
   max_memory_restart: '769M', // Configuração para reiniciar quando atingir 769 MB de memória
   node_args: '--max-old-space-size=769', // Limite de memória do Node.js para 769 MB
   watch: false


### PR DESCRIPTION
## Summary
- load env file when starting backend via pm2
- document pm2 usage

## Testing
- `npm test --prefix backend` *(fails: Cannot find "dist/config/database.js")*

------
https://chatgpt.com/codex/tasks/task_e_6874631c27c883279a8aee08296be7a5