### PR TITLE
Add AI prompt support for queues

### DIFF
--- a/backend/src/controllers/QueueController.ts
+++ b/backend/src/controllers/QueueController.ts
@@ -38,7 +38,8 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
     ativarRoteador,
     integrationId,
     fileListId,
-    closeTicket
+    closeTicket,
+    promptId
   } = req.body;
   const { companyId } = req.user;
 
@@ -55,7 +56,8 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
     orderQueue: orderQueue === "" ? null : orderQueue,
     integrationId: integrationId === "" ? null : integrationId,
     fileListId: fileListId === "" ? null : fileListId,
-    closeTicket
+    closeTicket,
+    promptId: promptId === "" ? null : promptId
   });
 
   const io = getIO();
@@ -96,7 +98,8 @@ export const update = async (
     ativarRoteador,
     integrationId,
     fileListId,
-    closeTicket
+    closeTicket,
+    promptId
   } = req.body;
 
   const queue = await UpdateQueueService(queueId, 
@@ -111,7 +114,8 @@ export const update = async (
     orderQueue: orderQueue === "" ? null : orderQueue,
     integrationId: integrationId === "" ? null : integrationId,
     fileListId: fileListId === "" ? null : fileListId,
-    closeTicket},
+    closeTicket,
+    promptId: promptId === "" ? null : promptId},
     companyId);
 
   const io = getIO();

--- a/backend/src/database/migrations/20250801000003-add-promptId-Queues.ts
+++ b/backend/src/database/migrations/20250801000003-add-promptId-Queues.ts
@@ -1,0 +1,16 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return queryInterface.addColumn("Queues", "promptId", {
+      type: DataTypes.INTEGER,
+      references: { model: "Prompts", key: "id" },
+      onUpdate: "CASCADE",
+      onDelete: "SET NULL"
+    });
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return queryInterface.removeColumn("Queues", "promptId");
+  }
+};

--- a/backend/src/models/Queue.ts
+++ b/backend/src/models/Queue.ts
@@ -107,6 +107,13 @@ class Queue extends Model<Queue> {
 
   @BelongsTo(() => Files)
   files: Files;
+
+  @ForeignKey(() => Prompt)
+  @Column
+  promptId: number;
+
+  @BelongsTo(() => Prompt)
+  promptSelected: Prompt;
   
   @Default(false)
   @Column

--- a/backend/src/services/QueueService/CreateQueueService.ts
+++ b/backend/src/services/QueueService/CreateQueueService.ts
@@ -20,6 +20,7 @@ interface QueueData {
   integrationId?: number;
   fileListId?: number;
   closeTicket?: boolean;
+  promptId?: number | null;
 }
 
 const CreateQueueService = async (queueData: QueueData): Promise<Queue> => {

--- a/backend/src/services/QueueService/ListQueuesService.ts
+++ b/backend/src/services/QueueService/ListQueuesService.ts
@@ -1,4 +1,5 @@
 import Queue from "../../models/Queue";
+import Prompt from "../../models/Prompt";
 
 interface Request {
   companyId: number;
@@ -9,6 +10,12 @@ const ListQueuesService = async ({ companyId }: Request): Promise<Queue[]> => {
     where: {
       companyId
     },
+    include: [
+      {
+        model: Prompt,
+        as: "promptSelected"
+      }
+    ],
     order: [["orderQueue", "ASC"]],
   });
 

--- a/backend/src/services/QueueService/ShowQueueService.ts
+++ b/backend/src/services/QueueService/ShowQueueService.ts
@@ -2,6 +2,7 @@ import AppError from "../../errors/AppError";
 import Chatbot from "../../models/Chatbot";
 import Queue from "../../models/Queue";
 import User from "../../models/User";
+import Prompt from "../../models/Prompt";
 
 const ShowQueueService = async (
   queueId: number | string,
@@ -12,17 +13,22 @@ const ShowQueueService = async (
       id: queueId,
       companyId
     },
-    include: [{
-      model: Chatbot,
-      as: "chatbots",
-      include: [
-        {
-          model: User,
-          as: "user"
-        },
-      ]
-    }
-  ],
+    include: [
+      {
+        model: Chatbot,
+        as: "chatbots",
+        include: [
+          {
+            model: User,
+            as: "user"
+          },
+        ]
+      },
+      {
+        model: Prompt,
+        as: "promptSelected"
+      }
+    ],
     order: [
       [{ model: Chatbot, as: "chatbots" }, "id", "asc"],
       ["id", "ASC"]

--- a/backend/src/services/QueueService/UpdateQueueService.ts
+++ b/backend/src/services/QueueService/UpdateQueueService.ts
@@ -19,6 +19,7 @@ interface QueueData {
   integrationId?: number | null;
   fileListId?: number | null;
   closeTicket?: boolean;
+  promptId?: number | null;
 }
 
 const UpdateQueueService = async (

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -489,6 +489,7 @@ const messages = {
           outOfHoursMessage: "Mensaje fuera de horario de atención",
           token: "Token",
           integrationId: "Integración",
+          prompt: "Prompt",
           fileListId: "Listado de archivos",
           closeTicket: "Cerrar ticket",
           queueType: "Tipo de menu",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -500,6 +500,7 @@ const messages = {
           outOfHoursMessage: "Mensagem de fora de expediente",
           token: "Token",
           integrationId: "Integração",
+          prompt: "Prompt",
           fileListId: "Lista de arquivos",
           closeTicket: "Fechar ticket",
           queueType: "Tipo de menu",


### PR DESCRIPTION
## Summary
- allow selecting an AI prompt for service queues
- include selected prompt when creating/updating queues
- expose associated prompt via queue services
- add DB migration for queue `promptId`
- fetch prompts in queue modal and add a prompt selector
- update Portuguese and Spanish translations

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm test` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687468473d7883279b36ae5ef4f998ea