### PR TITLE
Fix rating verification

### DIFF
--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -3308,6 +3308,7 @@ export const verifyRating = (ticketTraking: TicketTraking) => {
     ticketTraking &&
     ticketTraking.finishedAt === null &&
     ticketTraking.closedAt !== null &&
+    ticketTraking.userId !== null &&
     ticketTraking.ratingAt === null
   ) {
     return true;
@@ -4307,6 +4308,10 @@ const handleMessage = async (
       companyId,
       userId,
       whatsappId: whatsapp?.id
+    });
+
+    await ticketTraking.update({
+      userId: ticket.userId
     });
 
     let useLGPD = false;

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -3308,7 +3308,6 @@ export const verifyRating = (ticketTraking: TicketTraking) => {
     ticketTraking &&
     ticketTraking.finishedAt === null &&
     ticketTraking.closedAt !== null &&
-    ticketTraking.userId !== null &&
     ticketTraking.ratingAt === null
   ) {
     return true;


### PR DESCRIPTION
## Summary
- remove userId validation from verifyRating so rating can be handled even when userId is null

## Testing
- `npm test` *(fails: Cannot run database migrations)*

------
https://chatgpt.com/codex/tasks/task_e_687464b9554c83278c5cea64c2d7c996