### PR TITLE
Fix parentId handling in QueueOption list service

### DIFF
--- a/backend/src/services/QueueOptionService/ListService.ts
+++ b/backend/src/services/QueueOptionService/ListService.ts
@@ -19,12 +19,13 @@ const ListService = async ({ queueId, queueOptionId, parentId }: QueueOptionFilt
     whereOptions.id = queueOptionId;
   }
 
-  if (parentId == -1) {
-    whereOptions.parentId = null;
-  }
+  const parentIdNumber =
+    typeof parentId === "number" ? parentId : Number(parentId);
 
-  if (parentId > 0) {
-    whereOptions.parentId = parentId;
+  if (parentIdNumber === -1) {
+    whereOptions.parentId = null;
+  } else if (!isNaN(parentIdNumber) && parentIdNumber > 0) {
+    whereOptions.parentId = parentIdNumber;
   }
 
   const queueOptions = await QueueOption.findAll({


### PR DESCRIPTION
## Summary
- resolve type-check issue for parentId

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Cannot find "/workspace/teste/backend/dist/config/database.js". Have you run "sequelize init"?)*

------
https://chatgpt.com/codex/tasks/task_e_68746de2b46c83279acd3f6014db799b