### PR TITLE
Add promptId property to QueueData interface

### DIFF
--- a/backend/src/interfaces/QueueData.ts
+++ b/backend/src/interfaces/QueueData.ts
@@ -1,0 +1,18 @@
+import Chatbot from "../models/Chatbot";
+
+export interface QueueData {
+  name?: string;
+  color?: string;
+  companyId?: number;
+  greetingMessage?: string;
+  outOfHoursMessage?: string;
+  schedules?: any[];
+  chatbots?: Chatbot[];
+  orderQueue?: number;
+  ativarRoteador?: boolean;
+  tempoRoteador: number;
+  integrationId?: number | null;
+  fileListId?: number | null;
+  promptId?: number | null;
+  closeTicket?: boolean;
+}

--- a/backend/src/services/QueueService/CreateQueueService.ts
+++ b/backend/src/services/QueueService/CreateQueueService.ts
@@ -5,23 +5,7 @@ import Company from "../../models/Company";
 import Plan from "../../models/Plan";
 import Chatbot from "../../models/Chatbot";
 import User from "../../models/User";
-
-interface QueueData {
-  name: string;
-  color: string;
-  companyId: number;
-  greetingMessage?: string;
-  outOfHoursMessage?: string;
-  schedules?: any[];
-  chatbots?: Chatbot[];
-  orderQueue?: number;
-  ativarRoteador?: boolean;
-  tempoRoteador: number;
-  integrationId?: number;
-  fileListId?: number;
-  closeTicket?: boolean;
-  promptId?: number | null;
-}
+import { QueueData } from "../../interfaces/QueueData";
 
 const CreateQueueService = async (queueData: QueueData): Promise<Queue> => {
   const { color, name, companyId } = queueData;

--- a/backend/src/services/QueueService/UpdateQueueService.ts
+++ b/backend/src/services/QueueService/UpdateQueueService.ts
@@ -5,22 +5,7 @@ import Chatbot from "../../models/Chatbot";
 import Queue from "../../models/Queue";
 import ShowQueueService from "./ShowQueueService";
 import User from "../../models/User";
-
-interface QueueData {
-  name?: string;
-  color?: string;
-  greetingMessage?: string;
-  outOfHoursMessage?: string;
-  schedules?: any[];
-  chatbots?: Chatbot[];
-  orderQueue?: number;
-  ativarRoteador?: boolean;
-  tempoRoteador: number;
-  integrationId?: number | null;
-  fileListId?: number | null;
-  closeTicket?: boolean;
-  promptId?: number | null;
-}
+import { QueueData } from "../../interfaces/QueueData";
 
 const UpdateQueueService = async (
   queueId: number | string,


### PR DESCRIPTION
## Summary
- define a shared `QueueData` interface with `promptId`
- import `QueueData` in queue services

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687472d96a348327bda469fb6ee3af99