### PR TITLE
Fix queue migration idempotency

### DIFF
--- a/backend/src/database/migrations/20250801000003-add-promptId-Queues.ts
+++ b/backend/src/database/migrations/20250801000003-add-promptId-Queues.ts
@@ -1,8 +1,16 @@
 import { QueryInterface, DataTypes } from "sequelize";
 
 module.exports = {
-  up: (queryInterface: QueryInterface) => {
-    return queryInterface.addColumn("Queues", "promptId", {
+  up: async (queryInterface: QueryInterface) => {
+    const table = "Queues";
+    const column = "promptId";
+
+    const tableInfo = await queryInterface.describeTable(table);
+    if (tableInfo[column]) {
+      return Promise.resolve();
+    }
+
+    return queryInterface.addColumn(table, column, {
       type: DataTypes.INTEGER,
       references: { model: "Prompts", key: "id" },
       onUpdate: "CASCADE",


### PR DESCRIPTION
## Summary
- fix migration to add `promptId` to `Queues` only if missing

## Testing
- `npm run build` *(fails: Cannot find `dist/config/database.js`)*
- `npm test` *(fails: missing database configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687476e2b1a88327ba7811c9ed6b9800