### PR TITLE
Enable queue prompt responses

### DIFF
--- a/backend/src/services/TicketServices/ShowTicketService.ts
+++ b/backend/src/services/TicketServices/ShowTicketService.ts
@@ -9,6 +9,7 @@ import Whatsapp from "../../models/Whatsapp";
 import Company from "../../models/Company";
 import QueueIntegrations from "../../models/QueueIntegrations";
 import TicketTag from "../../models/TicketTag";
+import Prompt from "../../models/Prompt";
 
 const ShowTicketService = async (
   id: string | number,
@@ -70,7 +71,10 @@ const ShowTicketService = async (
         model: Queue,
         as: "queue",
         attributes: ["id", "name", "color"],
-        include: ["chatbots"]
+        include: [
+          "chatbots",
+          { model: Prompt, as: "promptSelected" }
+        ]
       },
       {
         model: User,

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -4654,6 +4654,39 @@ const handleMessage = async (
 
 
 
+    //openai na fila
+    if (
+      ticket.queue &&
+      ticket.queue.promptSelected &&
+      !isGroup &&
+      !msg.key.fromMe &&
+      !ticket.userId
+    ) {
+      const qPrompt = ticket.queue.promptSelected;
+      const openAiSettings = {
+        name: qPrompt.name,
+        prompt: qPrompt.prompt,
+        voice: qPrompt.voice,
+        voiceKey: qPrompt.voiceKey,
+        voiceRegion: qPrompt.voiceRegion,
+        maxTokens: qPrompt.maxTokens,
+        temperature: qPrompt.temperature,
+        apiKey: qPrompt.apiKey,
+        queueId: qPrompt.queueId,
+        maxMessages: qPrompt.maxMessages
+      };
+
+      await handleOpenAi(
+        openAiSettings,
+        msg,
+        wbot,
+        ticket,
+        contact,
+        mediaSent,
+        ticketTraking
+      );
+    }
+
     //openai na conexao
     if (
       !ticket.queue &&


### PR DESCRIPTION
## Summary
- include queue prompt data when showing a ticket
- run OpenAI handler when a queue has a prompt
- fix OpenAI settings type for queue prompts

## Testing
- `npm run build`
- `npm test` *(fails: sequelize db tools missing)*

------
https://chatgpt.com/codex/tasks/task_e_68747c0b951c832795ce4710dc303706