### PR TITLE
Handle exit commands before AI processing

### DIFF
--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -4314,6 +4314,25 @@ const handleMessage = async (
       userId: ticket.userId
     });
 
+    const normalizedBody = bodyMessage?.trim().toLowerCase();
+
+    if (!msg.key.fromMe && normalizedBody === "#") {
+      await sayChatbot(ticket.queueId, wbot, ticket, contact, msg, ticketTraking);
+      return;
+    }
+
+    if (!msg.key.fromMe && normalizedBody === "sair") {
+      const ticketData = {
+        status: "closed",
+        sendFarewellMessage: true,
+        amountUsedBotQueues: 0,
+        isBot: false
+      };
+
+      await UpdateTicketService({ ticketData, ticketId: ticket.id, companyId });
+      return;
+    }
+
     let useLGPD = false;
 
     try {


### PR DESCRIPTION
## Summary
- detect `#` and `Sair` before chatbot/AI processing
- stop the openAI flow and close the ticket when user exits

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: sequelize not found)*

------
https://chatgpt.com/codex/tasks/task_e_687487acf70c83279e66d72943b04828