### PR TITLE
Fix ticket creation during chip maturation

### DIFF
--- a/backend/src/services/MaturationService/JobRunner.ts
+++ b/backend/src/services/MaturationService/JobRunner.ts
@@ -7,6 +7,8 @@ import { MaturationJob } from "./MaturationManager";
 import isWhatsappConnected from "../../helpers/isWhatsappConnected";
 import logger from "../../utils/logger";
 
+const MATURATION_PREFIX = "\u2063";
+
 class JobRunner {
   private timeout?: NodeJS.Timeout;
 
@@ -54,6 +56,7 @@ class JobRunner {
         to = chips[Math.floor(Math.random() * chips.length)];
       }
       const msg = this.job.conversations[this.job.currentIndex % this.job.conversations.length];
+      const sendBody = `${MATURATION_PREFIX}${msg}`;
       this.job.currentIndex += 1;
       this.job.lastFrom = from;
 
@@ -66,7 +69,7 @@ class JobRunner {
           error = "sender disconnected";
         } else {
           try {
-            await SendMessage(whatsapp, { number: to, body: msg, companyId: this.job.companyId });
+            await SendMessage(whatsapp, { number: to, body: sendBody, companyId: this.job.companyId });
             success = true;
           } catch (err: any) {
             error = err.message;

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -95,6 +95,8 @@ import ShowTicketService from "../TicketServices/ShowTicketService";
 import { handleOpenAi } from "../IntegrationsServices/OpenAiService";
 import { IOpenAi } from "../../@types/openai";
 
+const MATURATION_PREFIX = "\u2063";
+
 const os = require("os");
 
 const request = require("request");
@@ -5145,6 +5147,9 @@ const verifyCampaignMessageAndCloseTicket = async (
 
   const io = getIO();
   const body = await getBodyMessage(message);
+  if (body && body.includes(MATURATION_PREFIX)) {
+    return;
+  }
   const isCampaign = /\u200c/.test(body);
 
   if (message.key.fromMe && isCampaign) {
@@ -5235,6 +5240,9 @@ const wbotMessageListener = (wbot: Session, companyId: number): void => {
         let isCampaign = false;
         let body = await getBodyMessage(message);
         const fromMe = message?.key?.fromMe;
+        if (body && body.includes(MATURATION_PREFIX)) {
+          return;
+        }
         if (fromMe) {
           isCampaign = /\u200c/.test(body);
         } else {


### PR DESCRIPTION
## Summary
- mark messages from the chip maturation job with an invisible prefix
- ignore messages containing this prefix in the WhatsApp listener

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: missing TS dependencies)*
- `npm test` *(fails: `sequelize` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757968b9548327a7a90560967cd279