### PR TITLE
Fix botFinishAt scheduling with database time

### DIFF
--- a/backend/src/services/IntegrationsServices/OpenAiService.ts
+++ b/backend/src/services/IntegrationsServices/OpenAiService.ts
@@ -13,6 +13,7 @@ import { isNil, isNull } from "lodash";
 import fs from "fs";
 import path, { join } from "path";
 import moment from "moment";
+import { Sequelize } from "sequelize";
 
 import OpenAI from "openai";
 import Ticket from "../../models/Ticket";
@@ -182,7 +183,9 @@ export const handleOpenAi = async (
       });
       await verifyMessage(sentMessage!, ticket, contact);
       if (openAiSettings.finishTicket > 0) {
-        await ticket.update({ botFinishAt: moment().add(openAiSettings.finishTicket, "minutes").toDate() });
+        await ticket.update({
+          botFinishAt: Sequelize.literal(`NOW() + INTERVAL '${openAiSettings.finishTicket} minutes'`)
+        });
       }
     } else {
       console.log(179, "OpenAiService");
@@ -212,7 +215,9 @@ export const handleOpenAi = async (
             wbot
           );
           if (openAiSettings.finishTicket > 0) {
-            await ticket.update({ botFinishAt: moment().add(openAiSettings.finishTicket, "minutes").toDate() });
+            await ticket.update({
+              botFinishAt: Sequelize.literal(`NOW() + INTERVAL '${openAiSettings.finishTicket} minutes'`)
+            });
           }
           deleteFileSync(`${publicFolder}/${fileNameWithOutExtension}.mp3`);
           deleteFileSync(`${publicFolder}/${fileNameWithOutExtension}.wav`);
@@ -298,7 +303,9 @@ export const handleOpenAi = async (
             wbot
           );
           if (openAiSettings.finishTicket > 0) {
-            await ticket.update({ botFinishAt: moment().add(openAiSettings.finishTicket, "minutes").toDate() });
+            await ticket.update({
+              botFinishAt: Sequelize.literal(`NOW() + INTERVAL '${openAiSettings.finishTicket} minutes'`)
+            });
           }
           deleteFileSync(`${publicFolder}/${fileNameWithOutExtension}.mp3`);
           deleteFileSync(`${publicFolder}/${fileNameWithOutExtension}.wav`);

--- a/backend/src/services/WbotServices/wbotClosedTickets.ts
+++ b/backend/src/services/WbotServices/wbotClosedTickets.ts
@@ -5,6 +5,7 @@ import { getIO } from "../../libs/socket"
 import formatBody from "../../helpers/Mustache";
 import SendWhatsAppMessage from "./SendWhatsAppMessage";
 import moment from "moment";
+import { Sequelize } from "sequelize";
 import ShowTicketService from "../TicketServices/ShowTicketService";
 import { verifyMessage } from "./wbotMessageListener";
 import TicketTraking from "../../models/TicketTraking";
@@ -36,7 +37,7 @@ const handleBotAutoCloseTickets = async (companyId: number, whatsapp: Whatsapp) 
       status: "open",
       companyId,
       whatsappId: whatsapp.id,
-      botFinishAt: { [Op.lt]: new Date() }
+      botFinishAt: { [Op.lt]: Sequelize.literal('NOW()') }
     }
   });
 


### PR DESCRIPTION
## Summary
- rely on the database clock when scheduling ticket auto close
- use Sequelize `NOW()` for comparisons

## Testing
- `npm test` *(fails: Cannot find dist/config/database.js)*

------
https://chatgpt.com/codex/tasks/task_e_6876f7c738448327af5182d54a84c5db