### PR TITLE
Fix default image lookup with multiple FRONTEND_URLs

### DIFF
--- a/backend/src/helpers/GetNoPictureUrl.ts
+++ b/backend/src/helpers/GetNoPictureUrl.ts
@@ -1,0 +1,20 @@
+import axios from "axios";
+
+const GetNoPictureUrl = async (): Promise<string> => {
+  const urls = process.env.FRONTEND_URL
+    ? process.env.FRONTEND_URL.split(',').map(u => u.trim()).filter(Boolean)
+    : [];
+
+  for (const url of urls) {
+    try {
+      await axios.head(`${url}/nopicture.png`);
+      return `${url}/nopicture.png`;
+    } catch (err) {
+      // Try next URL
+    }
+  }
+
+  return urls.length ? `${urls[0]}/nopicture.png` : "/nopicture.png";
+};
+
+export default GetNoPictureUrl;

--- a/backend/src/models/Contact.ts
+++ b/backend/src/models/Contact.ts
@@ -116,8 +116,14 @@ class Contact extends Model<Contact> {
   get urlPicture(): string | null {
     if (this.getDataValue("urlPicture")) {
       
-      return this.getDataValue("urlPicture") === 'nopicture.png' ?   `${process.env.FRONTEND_URL}/nopicture.png` :
-      `${process.env.BACKEND_URL}${process.env.PROXY_PORT ?`:${process.env.PROXY_PORT}`:""}/public/company${this.companyId}/contacts/${this.getDataValue("urlPicture")}` 
+      const domains = process.env.FRONTEND_URL
+        ? process.env.FRONTEND_URL.split(',').map(d => d.trim())
+        : [];
+      const frontend = domains[0] || "";
+
+      return this.getDataValue("urlPicture") === "nopicture.png"
+        ? `${frontend}/nopicture.png`
+        : `${process.env.BACKEND_URL}${process.env.PROXY_PORT ? `:${process.env.PROXY_PORT}` : ""}/public/company${this.companyId}/contacts/${this.getDataValue("urlPicture")}`
 
     }
     return null;

--- a/backend/src/services/ContactServices/CreateOrUpdateContactService.ts
+++ b/backend/src/services/ContactServices/CreateOrUpdateContactService.ts
@@ -8,6 +8,7 @@ import logger from "../../utils/logger";
 import { isNil } from "lodash";
 import Whatsapp from "../../models/Whatsapp";
 import * as Sentry from "@sentry/node";
+import GetNoPictureUrl from "../../helpers/GetNoPictureUrl";
 
 const axios = require("axios");
 
@@ -143,7 +144,7 @@ const CreateOrUpdateContactService = async ({
             );
           } catch (e) {
             Sentry.captureException(e);
-            profilePicUrl = `${process.env.FRONTEND_URL}/nopicture.png`;
+            profilePicUrl = await GetNoPictureUrl();
           }
           contact.profilePicUrl = profilePicUrl;
           updateImage = true;
@@ -176,7 +177,7 @@ const CreateOrUpdateContactService = async ({
         );
       } catch (e) {
         Sentry.captureException(e);
-        profilePicUrl = `${process.env.FRONTEND_URL}/nopicture.png`;
+        profilePicUrl = await GetNoPictureUrl();
       }
 
       contact = await Contact.create({

--- a/backend/src/services/WbotServices/GetProfilePicUrl.ts
+++ b/backend/src/services/WbotServices/GetProfilePicUrl.ts
@@ -1,6 +1,7 @@
 import GetDefaultWhatsApp from "../../helpers/GetDefaultWhatsApp";
 import { getWbot } from "../../libs/wbot";
 import Contact from "../../models/Contact";
+import GetNoPictureUrl from "../../helpers/GetNoPictureUrl";
 
 const GetProfilePicUrl = async (
   number: string,
@@ -13,9 +14,12 @@ const GetProfilePicUrl = async (
 
   let profilePicUrl: string;
   try {
-    profilePicUrl = await wbot.profilePictureUrl(contact && contact.isGroup ? contact.remoteJid:`${number}@s.whatsapp.net`, "image");
+    profilePicUrl = await wbot.profilePictureUrl(
+      contact && contact.isGroup ? contact.remoteJid : `${number}@s.whatsapp.net`,
+      "image"
+    );
   } catch (error) {
-    profilePicUrl = `${process.env.FRONTEND_URL}/nopicture.png`;
+    profilePicUrl = await GetNoPictureUrl();
   }
 
   return profilePicUrl;

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -6,6 +6,7 @@ import * as Sentry from "@sentry/node";
 import { isNil, isNull } from "lodash";
 import { REDIS_URI_MSG_CONN } from "../../config/redis";
 import axios from "axios";
+import GetNoPictureUrl from "../../helpers/GetNoPictureUrl";
 
 import {
   downloadMediaMessage,
@@ -5397,7 +5398,7 @@ const wbotMessageListener = (wbot: Session, companyId: number): void => {
          profilePicUrl = await wbot.profilePictureUrl(group.id, "image");
        } catch (e) {
          Sentry.captureException(e);
-         profilePicUrl = `${process.env.FRONTEND_URL}/nopicture.png`;
+         profilePicUrl = await GetNoPictureUrl();
        }
       const contactData = {
         name: nameGroup,


### PR DESCRIPTION
## Summary
- add helper `GetNoPictureUrl` to try multiple domains for `/nopicture.png`
- use this fallback when creating or updating contacts
- use the helper in profile picture utilities and listeners
- handle comma separated URLs in `Contact` model getter

## Testing
- `npm test` *(fails: Cannot find `/workspace/teste/backend/dist/config/database.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6879205f406c8327b8fb660e85e18755