### PR TITLE
Add prompt variants

### DIFF
--- a/backend/src/controllers/PromptController.ts
+++ b/backend/src/controllers/PromptController.ts
@@ -39,8 +39,8 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
   const [, token] = authHeader.split(" ");
   const decoded = verify(token, authConfig.secret);
   const { companyId } = decoded as TokenPayload;
-  const { name, apiKey, prompt, maxTokens, temperature, promptTokens, completionTokens, totalTokens, queueId, maxMessages,voice,voiceKey,voiceRegion } = req.body;
-  const promptTable = await CreatePromptService({ name, apiKey, prompt, maxTokens, temperature, promptTokens, completionTokens, totalTokens, queueId, maxMessages, companyId,voice,voiceKey,voiceRegion });
+  const { name, apiKey, prompt, prompt1, prompt2, prompt3, activePrompt, rotatePrompts, maxTokens, temperature, promptTokens, completionTokens, totalTokens, queueId, maxMessages,voice,voiceKey,voiceRegion } = req.body;
+  const promptTable = await CreatePromptService({ name, apiKey, prompt, prompt1, prompt2, prompt3, activePrompt, rotatePrompts, maxTokens, temperature, promptTokens, completionTokens, totalTokens, queueId, maxMessages, companyId,voice,voiceKey,voiceRegion });
 
   const io = getIO();
   io.of(String(companyId))

--- a/backend/src/database/migrations/20250901000000-add-prompt-variants-to-prompts.ts
+++ b/backend/src/database/migrations/20250901000000-add-prompt-variants-to-prompts.ts
@@ -1,0 +1,33 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return Promise.all([
+      queryInterface.addColumn("Prompts", "prompt1", {
+        type: DataTypes.TEXT,
+        allowNull: true
+      }),
+      queryInterface.addColumn("Prompts", "prompt2", {
+        type: DataTypes.TEXT,
+        allowNull: true
+      }),
+      queryInterface.addColumn("Prompts", "prompt3", {
+        type: DataTypes.TEXT,
+        allowNull: true
+      }),
+      queryInterface.addColumn("Prompts", "activePrompt", {
+        type: DataTypes.INTEGER,
+        defaultValue: 0
+      })
+    ]);
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return Promise.all([
+      queryInterface.removeColumn("Prompts", "prompt1"),
+      queryInterface.removeColumn("Prompts", "prompt2"),
+      queryInterface.removeColumn("Prompts", "prompt3"),
+      queryInterface.removeColumn("Prompts", "activePrompt")
+    ]);
+  }
+};

--- a/backend/src/database/migrations/20250902000000-add-prompt-rotation.ts
+++ b/backend/src/database/migrations/20250902000000-add-prompt-rotation.ts
@@ -1,0 +1,23 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return Promise.all([
+      queryInterface.addColumn("Prompts", "rotatePrompts", {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false
+      }),
+      queryInterface.addColumn("Tickets", "promptVariant", {
+        type: DataTypes.INTEGER,
+        allowNull: true
+      })
+    ]);
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return Promise.all([
+      queryInterface.removeColumn("Prompts", "rotatePrompts"),
+      queryInterface.removeColumn("Tickets", "promptVariant")
+    ]);
+  }
+};

--- a/backend/src/models/Prompt.ts
+++ b/backend/src/models/Prompt.ts
@@ -28,6 +28,24 @@ class Prompt extends Model<Prompt> {
   @Column
   prompt: string;
 
+  @AllowNull(true)
+  @Column
+  prompt1: string;
+
+  @AllowNull(true)
+  @Column
+  prompt2: string;
+
+  @AllowNull(true)
+  @Column
+  prompt3: string;
+
+  @Column({ defaultValue: 0 })
+  activePrompt: number;
+
+  @Column({ defaultValue: false })
+  rotatePrompts: boolean;
+
   @AllowNull(false)
   @Column
   apiKey: string;

--- a/backend/src/models/Ticket.ts
+++ b/backend/src/models/Ticket.ts
@@ -188,6 +188,12 @@ class Ticket extends Model<Ticket> {
 
   @Column
   botFinishAt: Date;
+
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: true
+  })
+  promptVariant: number;
 }
 
 export default Ticket;

--- a/backend/src/services/PromptServices/CreatePromptService.ts
+++ b/backend/src/services/PromptServices/CreatePromptService.ts
@@ -7,6 +7,11 @@ interface PromptData {
     name: string;
     apiKey: string;
     prompt: string;
+    prompt1?: string;
+    prompt2?: string;
+    prompt3?: string;
+    activePrompt?: number;
+    rotatePrompts?: boolean;
     maxTokens?: number;
     temperature?: number;
     promptTokens?: number;
@@ -22,7 +27,7 @@ interface PromptData {
 }
 
 const CreatePromptService = async (promptData: PromptData): Promise<Prompt> => {
-    const { name, apiKey, prompt, queueId,maxMessages,companyId, finishTicket } = promptData;
+    const { name, apiKey, prompt, prompt1, prompt2, prompt3, activePrompt, rotatePrompts, queueId, maxMessages, companyId, finishTicket } = promptData;
 
     const promptSchema = Yup.object().shape({
         name: Yup.string().required("ERR_PROMPT_NAME_INVALID"),

--- a/backend/src/services/PromptServices/UpdatePromptService.ts
+++ b/backend/src/services/PromptServices/UpdatePromptService.ts
@@ -8,6 +8,11 @@ interface PromptData {
     name: string;
     apiKey: string;
     prompt: string;
+    prompt1?: string;
+    prompt2?: string;
+    prompt3?: string;
+    activePrompt?: number;
+    rotatePrompts?: boolean;
     maxTokens?: number;
     temperature?: number;
     promptTokens?: number;
@@ -43,7 +48,7 @@ const UpdatePromptService = async ({
         maxMessages: Yup.number().required("ERR_PROMPT_MAX_MESSAGES_INVALID")
     });
 
-    const { name, apiKey, prompt, maxTokens, temperature, promptTokens, completionTokens, totalTokens, queueId, maxMessages, voice, voiceKey, voiceRegion, finishTicket } = promptData;
+    const { name, apiKey, prompt, prompt1, prompt2, prompt3, activePrompt, rotatePrompts, maxTokens, temperature, promptTokens, completionTokens, totalTokens, queueId, maxMessages, voice, voiceKey, voiceRegion, finishTicket } = promptData;
 
     try {
         await promptSchema.validate({ name, apiKey, prompt, maxTokens, temperature, promptTokens, completionTokens, totalTokens, queueId, maxMessages });
@@ -51,7 +56,7 @@ const UpdatePromptService = async ({
         throw new AppError(`${JSON.stringify(err, undefined, 2)}`);
     }
 
-    await promptTable.update({ name, apiKey, prompt, maxTokens, temperature, promptTokens, completionTokens, totalTokens, queueId, maxMessages, voice, voiceKey, voiceRegion, finishTicket });
+    await promptTable.update({ name, apiKey, prompt, prompt1, prompt2, prompt3, activePrompt, rotatePrompts, maxTokens, temperature, promptTokens, completionTokens, totalTokens, queueId, maxMessages, voice, voiceKey, voiceRegion, finishTicket });
     await promptTable.reload();
     return promptTable;
 };

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -4686,9 +4686,20 @@ const handleMessage = async (
       !ticket.userId
     ) {
       const qPrompt = ticket.queue.promptSelected;
+      let promptText = qPrompt.prompt;
+      if (qPrompt.rotatePrompts) {
+        const promptsArr = [qPrompt.prompt, qPrompt.prompt1, qPrompt.prompt2, qPrompt.prompt3];
+        let variant = ticket.promptVariant;
+        if (variant === null || variant === undefined) {
+          variant = qPrompt.activePrompt || 0;
+          await ticket.update({ promptVariant: variant });
+          await qPrompt.update({ activePrompt: (variant + 1) % 4 });
+        }
+        promptText = promptsArr[variant] || qPrompt.prompt;
+      }
       const openAiSettings = {
         name: qPrompt.name,
-        prompt: qPrompt.prompt,
+        prompt: promptText,
         voice: qPrompt.voice,
         voiceKey: qPrompt.voiceKey,
         voiceRegion: qPrompt.voiceRegion,
@@ -4719,9 +4730,33 @@ const handleMessage = async (
       !ticket.userId &&
       !isNil(whatsapp.promptId)
     ) {
-      const { prompt } = whatsapp;
+      const promptConfig = whatsapp.prompt;
+      let promptText = promptConfig.prompt;
+      if (promptConfig.rotatePrompts) {
+        const promptsArr = [promptConfig.prompt, promptConfig.prompt1, promptConfig.prompt2, promptConfig.prompt3];
+        let variant = ticket.promptVariant;
+        if (variant === null || variant === undefined) {
+          variant = promptConfig.activePrompt || 0;
+          await ticket.update({ promptVariant: variant });
+          await promptConfig.update({ activePrompt: (variant + 1) % 4 });
+        }
+        promptText = promptsArr[variant] || promptConfig.prompt;
+      }
+      const openAiSettings = {
+        name: promptConfig.name,
+        prompt: promptText,
+        voice: promptConfig.voice,
+        voiceKey: promptConfig.voiceKey,
+        voiceRegion: promptConfig.voiceRegion,
+        maxTokens: promptConfig.maxTokens,
+        temperature: promptConfig.temperature,
+        apiKey: promptConfig.apiKey,
+        queueId: promptConfig.queueId,
+        maxMessages: promptConfig.maxMessages,
+        finishTicket: promptConfig.finishTicket || 0
+      };
       await handleOpenAi(
-        prompt,
+        openAiSettings,
         msg,
         wbot,
         ticket,

--- a/frontend/src/components/PromptModal/index.js
+++ b/frontend/src/components/PromptModal/index.js
@@ -14,7 +14,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import { i18n } from "../../translate/i18n";
-import { MenuItem, FormControl, InputLabel, Select } from "@material-ui/core";
+import { MenuItem, FormControl, InputLabel, Select, Switch, FormControlLabel } from "@material-ui/core";
 import { Visibility, VisibilityOff } from "@material-ui/icons";
 import { InputAdornment, IconButton } from "@material-ui/core";
 import QueueSelectSingle from "../QueueSelectSingle";
@@ -59,6 +59,11 @@ const useStyles = makeStyles(theme => ({
 const PromptSchema = Yup.object().shape({
     name: Yup.string().min(5, "Muito curto!").max(100, "Muito longo!").required("Obrigatório"),
     prompt: Yup.string().min(50, "Muito curto!").required("Descreva o treinamento para Inteligência Artificial"),
+    prompt1: Yup.string(),
+    prompt2: Yup.string(),
+    prompt3: Yup.string(),
+    activePrompt: Yup.number(),
+    rotatePrompts: Yup.boolean(),
     voice: Yup.string().required("Informe o modo para Voz"),
     max_tokens: Yup.number().required("Informe o número máximo de tokens"),
     temperature: Yup.number().required("Informe a temperatura"),
@@ -80,6 +85,11 @@ const PromptModal = ({ open, onClose, promptId }) => {
     const initialState = {
         name: "",
         prompt: "",
+        prompt1: "",
+        prompt2: "",
+        prompt3: "",
+        activePrompt: 0,
+        rotatePrompts: false,
         voice: "texto",
         voiceKey: "",
         voiceRegion: "",
@@ -124,7 +134,12 @@ const PromptModal = ({ open, onClose, promptId }) => {
     };
 
     const handleSavePrompt = async values => {
-        const promptData = { ...values, voice: selectedVoice };
+        const promptsArr = [values.prompt, values.prompt1, values.prompt2, values.prompt3];
+        const promptData = {
+            ...values,
+            prompt: promptsArr[values.activePrompt] || values.prompt,
+            voice: selectedVoice
+        };
         if (!values.queueId) {
             toastError("Informe o setor");
             return;
@@ -213,8 +228,56 @@ const PromptModal = ({ open, onClose, promptId }) => {
                                     margin="dense"
                                     fullWidth
                                     required
-                                    rows={10}
+                                    rows={4}
                                     multiline={true}
+                                />
+                                <Field
+                                    as={TextField}
+                                    label={i18n.t("promptModal.form.prompt1")}
+                                    name="prompt1"
+                                    variant="outlined"
+                                    margin="dense"
+                                    fullWidth
+                                    rows={4}
+                                    multiline={true}
+                                />
+                                <Field
+                                    as={TextField}
+                                    label={i18n.t("promptModal.form.prompt2")}
+                                    name="prompt2"
+                                    variant="outlined"
+                                    margin="dense"
+                                    fullWidth
+                                    rows={4}
+                                    multiline={true}
+                                />
+                                <Field
+                                    as={TextField}
+                                    label={i18n.t("promptModal.form.prompt3")}
+                                    name="prompt3"
+                                    variant="outlined"
+                                    margin="dense"
+                                    fullWidth
+                                    rows={4}
+                                    multiline={true}
+                                />
+                                <FormControl fullWidth margin="dense" variant="outlined">
+                                    <InputLabel id="activePrompt-label">{i18n.t("promptModal.form.activePrompt")}</InputLabel>
+                                    <Field
+                                        as={Select}
+                                        labelId="activePrompt-label"
+                                        name="activePrompt"
+                                        label={i18n.t("promptModal.form.activePrompt")}
+                                    >
+                                        <MenuItem value={0}>{i18n.t("promptModal.form.prompt")}</MenuItem>
+                                        <MenuItem value={1}>{i18n.t("promptModal.form.prompt1")}</MenuItem>
+                                        <MenuItem value={2}>{i18n.t("promptModal.form.prompt2")}</MenuItem>
+                                        <MenuItem value={3}>{i18n.t("promptModal.form.prompt3")}</MenuItem>
+                                    </Field>
+                                </FormControl>
+                                <FormControlLabel
+                                    control={<Field as={Switch} name="rotatePrompts" color="primary" />}
+                                    label={i18n.t("promptModal.form.rotatePrompts")}
                                 />
                                 <QueueSelectSingle />
                                 <div className={classes.multFieldLine}>

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -407,6 +407,11 @@ const messages = {
         form: {
           name: "Nombre",
           prompt: "Prompt",
+          prompt1: "Prompt 1",
+          prompt2: "Prompt 2",
+          prompt3: "Prompt 3",
+          activePrompt: "Elegir Prompt",
+          rotatePrompts: "Activar rotación de prompts",
           voice: "Voz",
           max_tokens: "Máximo de Tokens en la respuesta",
           temperature: "Temperatura",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -416,6 +416,11 @@ const messages = {
         form: {
           name: "Nome",
           prompt: "Prompt",
+          prompt1: "Prompt 1",
+          prompt2: "Prompt 2",
+          prompt3: "Prompt 3",
+          activePrompt: "Escolher Prompt",
+          rotatePrompts: "Ativar rotatividade de prompts",
           voice: "Voz",
           max_tokens: "Máximo de Tokens na resposta",
           temperature: "Temperatura",


### PR DESCRIPTION
## Summary
- allow creating prompts with multiple variants and choose the active one
- support new fields in backend model and services
- add migration for new columns
- support new translations
- add rotation option for prompts and per-ticket variant selection

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm test -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a694244748327a5e444795f83fa88