### PR TITLE
Disable prompt field editing

### DIFF
--- a/frontend/src/components/PromptModal/index.js
+++ b/frontend/src/components/PromptModal/index.js
@@ -230,6 +230,7 @@ const PromptModal = ({ open, onClose, promptId }) => {
                                     required
                                     rows={4}
                                     multiline={true}
+                                    disabled
                                 />
                                 <Field
                                     as={TextField}


### PR DESCRIPTION
## Summary
- make main prompt text field read-only in PromptModal

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687aff7ebea88327ad82a9b3a2048fbc