### PR TITLE
Fix prompt selection logic

### DIFF
--- a/frontend/src/components/PromptModal/index.js
+++ b/frontend/src/components/PromptModal/index.js
@@ -134,10 +134,8 @@ const PromptModal = ({ open, onClose, promptId }) => {
     };
 
     const handleSavePrompt = async values => {
-        const promptsArr = [values.prompt, values.prompt1, values.prompt2, values.prompt3];
         const promptData = {
             ...values,
-            prompt: promptsArr[values.activePrompt] || values.prompt,
             voice: selectedVoice
         };
         if (!values.queueId) {


### PR DESCRIPTION
## Summary
- fix prompt modal to avoid overwriting the original prompt when saving

## Testing
- `npm test` in `backend` *(fails: Cannot find `/workspace/teste/backend/dist/config/database.js`)*
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_687b02094c28832785b3625421b21615