### PR TITLE
Fix prompt selection logic

### DIFF
--- a/frontend/src/components/PromptModal/index.js
+++ b/frontend/src/components/PromptModal/index.js
@@ -134,8 +134,11 @@ const PromptModal = ({ open, onClose, promptId }) => {
     };
 
     const handleSavePrompt = async values => {
+        const promptsArr = [values.prompt, values.prompt1, values.prompt2, values.prompt3];
+        const selectedPrompt = promptsArr[values.activePrompt];
         const promptData = {
             ...values,
+            prompt: selectedPrompt?.trim() ? selectedPrompt : values.prompt,
             voice: selectedVoice
         };
         if (!values.queueId) {


### PR DESCRIPTION
## Summary
- ensure correct prompt variant is sent when saving a prompt

## Testing
- `npm test` *(fails: sequelize not found / database not configured)*
- `npm test` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b06ae3f248327a6551b368c56ebc9