### PR TITLE
Fix prompt refresh on ticket restart

### DIFF
--- a/backend/src/services/TicketServices/UpdateTicketService.ts
+++ b/backend/src/services/TicketServices/UpdateTicketService.ts
@@ -104,7 +104,8 @@ const UpdateTicketService = async ({
       });
 
       await ticket.update({
-        status: "closed"
+        status: "closed",
+        promptVariant: null
       });
 
       io.of(String(companyId))
@@ -300,6 +301,7 @@ const UpdateTicketService = async ({
         lastFlowId: null,
         dataWebhook: null,
         hashFlowId: null,
+        promptVariant: null
       });
 
       io.of(String(companyId))
@@ -323,7 +325,8 @@ const UpdateTicketService = async ({
         let newTicketTransfer = ticket;
         if (oldQueueId !== queueId) {
           await ticket.update({
-            status: "closed"
+            status: "closed",
+            promptVariant: null
           });
 
           await ticket.reload();
@@ -692,7 +695,8 @@ const UpdateTicketService = async ({
       integrationId,
       typebotSessionId: !useIntegration ? null : ticket.typebotSessionId,
       typebotStatus: useIntegration,
-      unreadMessages
+      unreadMessages,
+      ...(status === "closed" ? { promptVariant: null } : {})
     });
 
     ticketTraking.queuedAt = moment().toDate();

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -1069,7 +1069,11 @@ export const verifyMediaMessage = async (
           "isBot"
         ],
         include: [
-          { model: Queue, as: "queue" },
+          {
+            model: Queue,
+            as: "queue",
+            include: [{ model: Prompt, as: "promptSelected" }]
+          },
           { model: User, as: "user" },
           { model: Contact, as: "contact" },
           { model: Whatsapp, as: "whatsapp" }
@@ -1150,7 +1154,11 @@ export const verifyMessage = async (
     await ticket.update({ status: "pending" });
     await ticket.reload({
       include: [
-        { model: Queue, as: "queue" },
+        {
+          model: Queue,
+          as: "queue",
+          include: [{ model: Prompt, as: "promptSelected" }]
+        },
         { model: User, as: "user" },
         { model: Contact, as: "contact" },
         { model: Whatsapp, as: "whatsapp" }
@@ -1656,7 +1664,15 @@ const verifyQueue = async (
         status: "pending"
       });
 
-    await ticket.reload();
+    await ticket.reload({
+      include: [
+        {
+          model: Queue,
+          as: "queue",
+          include: [{ model: Prompt, as: "promptSelected" }]
+        }
+      ]
+    });
   }
 
   if (String(selectedOption).toLocaleLowerCase() == "sair") {
@@ -3378,7 +3394,8 @@ export const handleRating = async (
   await ticket.update({
     isBot: false,
     status: "closed",
-    amountUsedBotQueuesNPS: 0
+    amountUsedBotQueuesNPS: 0,
+    promptVariant: null
   });
 
   //loga fim de atendimento
@@ -3543,7 +3560,11 @@ const flowbuilderIntegration = async (
     await ticket.update({ status: "pending" });
     await ticket.reload({
       include: [
-        { model: Queue, as: "queue" },
+        {
+          model: Queue,
+          as: "queue",
+          include: [{ model: Prompt, as: "promptSelected" }]
+        },
         { model: User, as: "user" },
         { model: Contact, as: "contact" }
       ]
@@ -5051,7 +5072,15 @@ const handleMessage = async (
       });
     }
 
-    await ticket.reload();
+    await ticket.reload({
+      include: [
+        {
+          model: Queue,
+          as: "queue",
+          include: [{ model: Prompt, as: "promptSelected" }]
+        }
+      ]
+    });
   } catch (err) {
     Sentry.captureException(err);
     console.log(err);
@@ -5209,7 +5238,7 @@ const verifyCampaignMessageAndCloseTicket = async (
       messageRecord !== null
     ) {
       const ticket = await Ticket.findByPk(messageRecord.ticketId);
-      await ticket.update({ status: "closed", amountUsedBotQueues: 0 });
+      await ticket.update({ status: "closed", amountUsedBotQueues: 0, promptVariant: null });
 
       io.of(String(companyId))
         // .to("open")


### PR DESCRIPTION
## Summary
- reset `promptVariant` when closing tickets
- reload ticket with updated queue prompt
- ensure closed tickets reset prompt rotation

## Testing
- `npx jest` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b141702848327b725343395ddba0e