### PR TITLE
Fix ffmpeg path for TTS conversion

### DIFF
--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -72,6 +72,7 @@ import ShowFileService from "../FileServices/ShowService";
 
 import OpenAI from "openai";
 import ffmpeg from "fluent-ffmpeg";
+import ffmpegPath from "@ffmpeg-installer/ffmpeg";
 import {
   SpeechConfig,
   SpeechSynthesizer,
@@ -96,6 +97,8 @@ import { FlowCampaignModel } from "../../models/FlowCampaign";
 import ShowTicketService from "../TicketServices/ShowTicketService";
 import { handleOpenAi } from "../IntegrationsServices/OpenAiService";
 import { IOpenAi } from "../../@types/openai";
+
+ffmpeg.setFfmpegPath(ffmpegPath.path);
 
 const MATURATION_PREFIX = "\u2063";
 


### PR DESCRIPTION
## Summary
- ensure ffmpeg binary is configured when converting TTS audio

## Testing
- `npm test` *(fails: `sequelize: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687b3416b3d48327b8f68e431950bede