### PR TITLE
fix: disable chatbot on agent started chats

### DIFF
--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -4917,7 +4917,8 @@ const handleMessage = async (
       !msg.key.fromMe &&
       !ticket.userId &&
       whatsapp.queues.length >= 1 &&
-      !ticket.useIntegration
+      !ticket.useIntegration &&
+      !ticket.fromMe
     ) {
       // console.log("antes do verifyqueue")
       await verifyQueue(wbot, msg, ticket, contact, settings, ticketTraking);


### PR DESCRIPTION
## Summary
- avoid automatic chatbot when attendant starts conversation

## Testing
- `npm test` (fails: Cannot find "/workspace/teste/backend/dist/config/database.js". Have you run "sequelize init"?)
- `npm run lint` (fails: numerous prettier/eslint errors)


------
https://chatgpt.com/codex/tasks/task_e_689647cd737c83278c27a1f4a155a434