### PR TITLE
fix: stop chatbot replies after agent takes ticket

### DIFF
--- a/backend/src/services/WbotServices/ChatBotListener.ts
+++ b/backend/src/services/WbotServices/ChatBotListener.ts
@@ -687,6 +687,9 @@ export const sayChatbot = async (
   msg: proto.IWebMessageInfo,
   ticketTraking: TicketTraking
 ): Promise<any> => {
+  if (ticket.userId) {
+    return;
+  }
   // console.log("LINHA 718")
   // const selectedOption =
   //   msg?.message?.buttonsResponseMessage?.selectedButtonId ||

--- a/backend/src/services/WbotServices/ChatbotListenerFacebook.ts
+++ b/backend/src/services/WbotServices/ChatbotListenerFacebook.ts
@@ -161,6 +161,9 @@ export const sayChatbot = async (
   contact: Contact,
   msg: any
 ): Promise<any> => {
+  if (ticket.userId) {
+    return;
+  }
   const selectedOption = msg.text;
   if (!queueId && selectedOption && msg.is_echo) return;
 

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -4344,12 +4344,12 @@ const handleMessage = async (
 
     const normalizedBody = bodyMessage?.trim().toLowerCase();
 
-    if (!msg.key.fromMe && normalizedBody === "#") {
+    if (!msg.key.fromMe && !ticket.user && normalizedBody === "#") {
       await sayChatbot(ticket.queueId, wbot, ticket, contact, msg, ticketTraking);
       return;
     }
 
-    if (!msg.key.fromMe && normalizedBody === "sair") {
+    if (!msg.key.fromMe && !ticket.user && normalizedBody === "sair") {
       const ticketData = {
         status: "closed",
         sendFarewellMessage: true,
@@ -5058,7 +5058,7 @@ const handleMessage = async (
     }
 
     if (ticket.queue && ticket.queueId && !msg.key.fromMe) {
-      if (!ticket.user || ticket.queue?.chatbots?.length > 0) {
+      if (!ticket.user) {
         await sayChatbot(
           ticket.queueId,
           wbot,


### PR DESCRIPTION
## Summary
- avoid bot answering when a ticket already has an assigned agent
- ignore `#` and `sair` chatbot commands once an agent is handling the ticket

## Testing
- `npm run build`
- `npm test` *(fails: waiting for database connection during migrations)*

------
https://chatgpt.com/codex/tasks/task_e_6896703b932083278897bbd8c9939183