### PR TITLE
fix: handle NPS rating before menu

### DIFF
--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -4422,6 +4422,24 @@ const handleMessage = async (
 
     let mediaSent: Message | undefined;
 
+    try {
+      if (!msg.key.fromMe && ticketTraking !== null && verifyRating(ticketTraking)) {
+        const rating = parseFloat(bodyMessage);
+        if (!isNaN(rating)) {
+          await handleRating(rating, ticket, ticketTraking);
+          await ticketTraking.update({
+            ratingAt: moment().toDate(),
+            finishedAt: moment().toDate(),
+            rated: true
+          });
+          return;
+        }
+      }
+    } catch (err) {
+      Sentry.captureException(err);
+      logger.error(`[handleRating] falha ao gravar rating:`, err);
+    }
+
     if (!useLGPD) {
       console.log("log... 3391");
       if (hasMedia) {
@@ -4449,25 +4467,6 @@ const handleMessage = async (
       }
     }
 
-    try {
-      if (!msg.key.fromMe) {
-        console.log("log... 3226");
-        console.log("log... 3227", { ticketTraking});
-        if (ticketTraking !== null && verifyRating(ticketTraking)) {
-          await handleRating(parseFloat(bodyMessage), ticket, ticketTraking);
-          await ticketTraking.update({
-            ratingAt: moment().toDate(),
-            finishedAt: moment().toDate(),
-            rated: true
-          });
-          return;
-        }
-      }
-    } catch (err) {
-      Sentry.captureException(err);
-      logger.error(`[handleRating] falha ao gravar rating:`, err);
-    }
-    
     // Atualiza o ticket se a ultima mensagem foi enviada por mim, para que possa ser finalizado.
     try {
       console.log("log... 3258");


### PR DESCRIPTION
## Summary
- handle NPS rating before chatbot queues to prevent menu loop

## Testing
- `npm test` *(fails: waiting on database migrations)*
- `npm run lint` *(fails: 3290 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68967697b26c832789c4faa0055198d1