### PR TITLE
feat: toggle chatbot based on ticket user

### DIFF
--- a/backend/src/services/TicketServices/FindOrCreateTicketService.ts
+++ b/backend/src/services/TicketServices/FindOrCreateTicketService.ts
@@ -74,7 +74,7 @@ const FindOrCreateTicketService = async (
         queueId: queueId !== ticket.queueId ? ticket.queueId : queueId,
       })
     } else {
-      await ticket.update({ unreadMessages, isBot: false });
+      await ticket.update({ unreadMessages, isBot: !ticket.userId });
     }
 
     ticket = await ShowTicketService(ticket.id, companyId);

--- a/backend/src/services/TicketServices/FindOrCreateTicketService_backup.ts
+++ b/backend/src/services/TicketServices/FindOrCreateTicketService_backup.ts
@@ -71,7 +71,7 @@ const FindOrCreateTicketService = async (
         queueId: queueId !== ticket.queueId ? ticket.queueId : queueId,
       })
     } else {
-      await ticket.update({ unreadMessages, isBot: false });
+      await ticket.update({ unreadMessages, isBot: !ticket.userId });
     }
 
     ticket = await ShowTicketService(ticket.id, companyId);

--- a/backend/src/services/TicketServices/UpdateTicketService.ts
+++ b/backend/src/services/TicketServices/UpdateTicketService.ts
@@ -72,7 +72,6 @@ const UpdateTicketService = async ({
       isTransfered = false,
       status
     } = ticketData;
-    let isBot: boolean | null = ticketData.isBot || false;
     let queueOptionId: number | null = ticketData.queueOptionId || null;
 
     const io = getIO();
@@ -84,6 +83,11 @@ const UpdateTicketService = async ({
     });
 
     let ticket = await ShowTicketService(ticketId, companyId);
+    let isBot: boolean | null = ticketData.isBot ?? ticket.isBot;
+
+    if (ticketData.userId !== undefined) {
+      isBot = ticketData.userId ? false : true;
+    }
 
 
 
@@ -136,7 +140,7 @@ const UpdateTicketService = async ({
       }
 
       // await CheckContactOpenTickets(ticket.contactId, ticket.whatsappId );
-      isBot = false;
+      isBot = userId ? false : true;
     }
 
     const ticketTraking = await FindOrCreateATicketTrakingService({


### PR DESCRIPTION
## Summary
- disable chatbot when a ticket is assigned to an agent
- automatically re-enable chatbot when ticket user is cleared

## Testing
- `npm test` *(fails: Cannot find "/workspace/teste/backend/dist/config/database.js". Have you run "sequelize init"?)*

------
https://chatgpt.com/codex/tasks/task_e_689680f7dd1c83278e806e1344b56fe2