### PR TITLE
fix: handle NPS rating input

### DIFF
--- a/backend/src/services/TicketServices/UpdateTicketService.ts
+++ b/backend/src/services/TicketServices/UpdateTicketService.ts
@@ -185,7 +185,8 @@ const UpdateTicketService = async ({
 
           await ticketTraking.update({
             userId: ticket.userId,
-            closedAt: moment().toDate()
+            closedAt: moment().toDate(),
+            rated: false
           });
 
           await CreateLogTicketService({

--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -1419,6 +1419,10 @@ const verifyQueue = async (
 ) => {
   const companyId = ticket.companyId;
 
+  if (ticket.status === "nps") {
+    return;
+  }
+
   console.log("verifyQueue");
   // console.log("GETTING WHATSAPP VERIFY QUEUE", ticket.whatsappId, wbot.id)
   const { queues, greetingMessage, maxUseBotQueues, timeUseBotQueues } =
@@ -4425,6 +4429,8 @@ const handleMessage = async (
     try {
       if (!msg.key.fromMe && ticketTraking !== null && verifyRating(ticketTraking)) {
         const rating = parseFloat(bodyMessage);
+        const companyId = ticket.companyId;
+
         if (!isNaN(rating)) {
           await handleRating(rating, ticket, ticketTraking);
           await ticketTraking.update({
@@ -4432,8 +4438,27 @@ const handleMessage = async (
             finishedAt: moment().toDate(),
             rated: true
           });
-          return;
+
+          const ticketData = {
+            status: "closed",
+            sendFarewellMessage: false
+          };
+
+          await UpdateTicketService({
+            ticketData,
+            ticketId: ticket.id,
+            companyId
+          });
+        } else {
+          const bodyErrorRating = `\u200eOpção inválida, envie apenas uma nota de 0 a 10.`;
+          const sentMessage = await SendWhatsAppMessage({
+            body: bodyErrorRating,
+            ticket
+          });
+          await verifyMessage(sentMessage, ticket, contact, ticketTraking);
         }
+
+        return;
       }
     } catch (err) {
       Sentry.captureException(err);
@@ -4917,7 +4942,8 @@ const handleMessage = async (
       !ticket.userId &&
       whatsapp.queues.length >= 1 &&
       !ticket.useIntegration &&
-      !ticket.fromMe
+      !ticket.fromMe &&
+      ticket.status !== "nps"
     ) {
       // console.log("antes do verifyqueue")
       await verifyQueue(wbot, msg, ticket, contact, settings, ticketTraking);


### PR DESCRIPTION
## Summary
- process NPS rating messages before queue/chatbot logic
- prompt customer for numeric rating and close ticket after valid score
- reset ticket tracking for NPS by clearing rated flag

## Testing
- `npm test` (fails: Cannot find "/workspace/teste/backend/dist/config/database.js". Have you run "sequelize init"?)
- `npm run lint` (fails: ✖ 3290 problems (3004 errors, 286 warnings))

------
https://chatgpt.com/codex/tasks/task_e_68968aa676f083278a615acf5ca03b77