### PR TITLE
Fix ticket closure after NPS rating

### DIFF
--- a/backend/src/services/FacebookServices/facebookMessageListener.ts
+++ b/backend/src/services/FacebookServices/facebookMessageListener.ts
@@ -633,12 +633,6 @@ export const handleMessage = async (
 
               await handleRating(parseFloat(bodyMessage), ticket, ticketTraking);
 
-              await ticketTraking.update({
-                ratingAt: moment().toDate(),
-                finishedAt: moment().toDate(),
-                rated: true
-              });
-
               return;
             } else {
 


### PR DESCRIPTION
## Summary
- ensure handleRating closes tickets and updates tracking after NPS score
- simplify message listeners to delegate NPS rating logic

## Testing
- `npm test` *(fails: Loaded configuration file "dist/config/database.js")*

------
https://chatgpt.com/codex/tasks/task_e_68969359dba88327bef16d5a28618619