### PR TITLE
fix: allow NPS rating without agent

### DIFF
--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -3335,7 +3335,6 @@ export const verifyRating = (ticketTraking: TicketTraking) => {
     ticketTraking &&
     ticketTraking.finishedAt === null &&
     ticketTraking.closedAt !== null &&
-    ticketTraking.userId !== null &&
     ticketTraking.ratingAt === null
   ) {
     return true;


### PR DESCRIPTION
## Summary
- allow recording NPS scores even when no agent handled ticket

## Testing
- `npm test` *(fails: Cannot find "/workspace/teste/backend/dist/config/database.js". Have you run "sequelize init"?)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896a1dfc28c83279744dca3fddc371e